### PR TITLE
fix(github): run ci also for external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
In public repositories, the CI should be also triggered by opening the PR, because push trigger wouldn't work for a branch, that was pushed into a fork. We need to think if we need to do the same for merge checks - I do think we might.