### PR TITLE
fix(sdk): fix datetime parsing in simple custom field

### DIFF
--- a/tests/responses/get_issue.json
+++ b/tests/responses/get_issue.json
@@ -32,6 +32,16 @@
         "id": "98-37",
         "$type": "StateBundleElement"
       },
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "state[1]",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "StateProjectCustomField"
+      },
       "name": "State",
       "id": "110-50",
       "$type": "StateIssueCustomField"
@@ -45,6 +55,16 @@
         "id": "1-10",
         "$type": "User"
       },
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "user[1]",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "UserProjectCustomField"
+      },
       "name": "Assignee",
       "id": "111-8",
       "$type": "SingleUserIssueCustomField"
@@ -55,42 +75,112 @@
         "id": "96-38",
         "$type": "EnumBundleElement"
       },
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "enum[1]",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "EnumProjectCustomField"
+      },
       "name": "Type",
       "id": "110-49",
       "$type": "SingleEnumIssueCustomField"
     },
     {
       "value": 1645110000000,
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "date",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "SimpleProjectCustomField"
+      },
       "name": "Due Date",
       "id": "145-34",
       "$type": "DateIssueCustomField"
     },
     {
       "value": 1623396729000,
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "date and time",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "SimpleProjectCustomField"
+      },
       "name": "Started at",
       "id": "145-35",
       "$type": "SimpleIssueCustomField"
     },
     {
-      "value": "100-003-675",
+      "value": "1623396729",
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "string",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "SimpleProjectCustomField"
+      },
       "name": "Multipass",
       "id": "145-36",
       "$type": "SimpleIssueCustomField"
     },
     {
       "value": 4003,
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "integer",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "SimpleProjectCustomField"
+      },
       "name": "Price",
       "id": "145-39",
       "$type": "SimpleIssueCustomField"
     },
     {
       "value": 3.1412,
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "float",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "SimpleProjectCustomField"
+      },
       "name": "Multiplier",
       "id": "145-37",
       "$type": "SimpleIssueCustomField"
     },
     {
       "value": null,
+      "projectCustomField": {
+        "field": {
+          "fieldType": {
+            "id": "string",
+            "$type": "FieldType"
+          },
+          "$type": "CustomField"
+        },
+        "$type": "SimpleProjectCustomField"
+      },
       "name": "Extra",
       "id": "145-38",
       "$type": "SimpleIssueCustomField"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,27 +53,27 @@ class TestClient(TestCase):
     @mock_response(url="https://server/api/issues/1", response_name="get_issue")
     def test_get_issue(self):
         self.assertEqual(
-            Issue(
+            Issue.construct(
                 type="Issue",
                 id="1-937",
-                idReadable="HD-25",
+                id_readable="HD-25",
                 created=datetime(2021, 2, 9, 14, 3, 11, tzinfo=timezone.utc),
                 updated=datetime(2021, 8, 22, 10, 28, 16, tzinfo=timezone.utc),
                 resolved=None,
-                project=Project(
+                project=Project.construct(
                     type="Project",
                     id="0-1",
                     name="Help Desk",
                     short_name="HD",
                 ),
-                reporter=User(
+                reporter=User.construct(
                     type="User",
                     id="1-3",
                     ring_id="b0fea1e1-ed18-43f6-a99d-40044fb1dfb0",
                     login="support",
                     email="support@example.com",
                 ),
-                updater=User(
+                updater=User.construct(
                     type="User",
                     id="1-17",
                     ring_id="c5d08431-dd52-4cdd-9911-7ec3a18ad117",
@@ -84,14 +84,14 @@ class TestClient(TestCase):
                 description="Issue description",
                 wikified_description="Wikified issue description",
                 tags=[
-                    IssueTag(type="IssueTag", id="5-7", name="Review"),
+                    IssueTag.construct(type="IssueTag", id="5-7", name="Review"),
                 ],
                 custom_fields=[
-                    StateIssueCustomField(
+                    StateIssueCustomField.construct(
                         id="110-50",
                         name="State",
                         type="StateIssueCustomField",
-                        value=StateBundleElement(
+                        value=StateBundleElement.construct(
                             id="98-37",
                             name="In Progress",
                             type="StateBundleElement",
@@ -107,11 +107,11 @@ class TestClient(TestCase):
                             type="StateProjectCustomField",
                         ),
                     ),
-                    SingleUserIssueCustomField(
+                    SingleUserIssueCustomField.construct(
                         id="111-8",
                         name="Assignee",
                         type="SingleUserIssueCustomField",
-                        value=User(
+                        value=User.construct(
                             type="User",
                             id="1-10",
                             ring_id="20e4e701-7e87-45f8-8492-c448600b7991",
@@ -127,11 +127,11 @@ class TestClient(TestCase):
                             type="UserProjectCustomField",
                         ),
                     ),
-                    SingleEnumIssueCustomField(
+                    SingleEnumIssueCustomField.construct(
                         id="110-49",
                         name="Type",
                         type="SingleEnumIssueCustomField",
-                        value=EnumBundleElement(
+                        value=EnumBundleElement.construct(
                             id="96-38",
                             name="Value One",
                             type="EnumBundleElement",
@@ -144,7 +144,7 @@ class TestClient(TestCase):
                             type="EnumProjectCustomField",
                         ),
                     ),
-                    DateIssueCustomField(
+                    DateIssueCustomField.construct(
                         id="145-34",
                         name="Due Date",
                         type="DateIssueCustomField",
@@ -156,7 +156,7 @@ class TestClient(TestCase):
                             ),
                         ),
                     ),
-                    SimpleIssueCustomField(
+                    SimpleIssueCustomField.construct(
                         id="145-35",
                         name="Started at",
                         type="SimpleIssueCustomField",
@@ -172,7 +172,7 @@ class TestClient(TestCase):
                             type="SimpleProjectCustomField",
                         ),
                     ),
-                    SimpleIssueCustomField(
+                    SimpleIssueCustomField.construct(
                         id="145-36",
                         name="Multipass",
                         type="SimpleIssueCustomField",
@@ -198,7 +198,7 @@ class TestClient(TestCase):
                             type="SimpleProjectCustomField",
                         ),
                     ),
-                    SimpleIssueCustomField(
+                    SimpleIssueCustomField.construct(
                         id="145-37",
                         name="Multiplier",
                         type="SimpleIssueCustomField",
@@ -211,7 +211,7 @@ class TestClient(TestCase):
                             type="SimpleProjectCustomField",
                         ),
                     ),
-                    SimpleIssueCustomField(
+                    SimpleIssueCustomField.construct(
                         id="145-38",
                         name="Extra",
                         type="SimpleIssueCustomField",
@@ -233,14 +233,14 @@ class TestClient(TestCase):
     def test_get_issue_comments(self):
         self.assertEqual(
             (
-                IssueComment(
+                IssueComment.construct(
                     type="IssueComment",
                     id="4-296",
                     text="*Hello*, world!",
                     text_preview="<strong>Hello</strong>, world!",
                     created=datetime(2021, 12, 14, 11, 17, 48, tzinfo=timezone.utc),
                     updated=None,
-                    author=User(
+                    author=User.construct(
                         type="User",
                         id="1-3",
                         ring_id="b0fea1e1-ed18-43f6-a99d-40044fb1dfb0",
@@ -250,14 +250,14 @@ class TestClient(TestCase):
                     attachments=[],
                     deleted=False,
                 ),
-                IssueComment(
+                IssueComment.construct(
                     type="IssueComment",
                     id="4-443",
                     text="Sample _comment_",
                     text_preview="Sample <em>comment</em>",
                     created=datetime(2021, 12, 15, 12, 51, 40, tzinfo=timezone.utc),
                     updated=datetime(2021, 12, 15, 13, 8, 20, tzinfo=timezone.utc),
-                    author=User(
+                    author=User.construct(
                         type="User",
                         id="1-17",
                         ring_id="c5d08431-dd52-4cdd-9911-7ec3a18ad117",
@@ -267,14 +267,14 @@ class TestClient(TestCase):
                     attachments=[],
                     deleted=True,
                 ),
-                IssueComment(
+                IssueComment.construct(
                     type="IssueComment",
                     id="4-678",
                     text="Comment with attachments",
                     text_preview="One attachment",
                     created=datetime(2021, 12, 21, 16, 41, 33, tzinfo=timezone.utc),
                     updated=None,
-                    author=User(
+                    author=User.construct(
                         type="User",
                         id="1-9",
                         ring_id="f19c93e1-833b-407b-a4de-7f9a3370aaf3",
@@ -282,7 +282,7 @@ class TestClient(TestCase):
                         email="sam@example.com",
                     ),
                     attachments=[
-                        IssueAttachment(
+                        IssueAttachment.construct(
                             id="8-312",
                             type="IssueAttachment",
                             created=datetime(2021, 12, 21, 16, 41, 33, tzinfo=timezone.utc),
@@ -303,13 +303,13 @@ class TestClient(TestCase):
     def test_get_projects(self):
         self.assertEqual(
             (
-                Project(
+                Project.construct(
                     type="Project",
                     id="0-0",
                     name="Demo project",
                     short_name="DEMO",
                 ),
-                Project(
+                Project.construct(
                     type="Project",
                     id="0-5",
                     name="Help Desk",
@@ -323,17 +323,17 @@ class TestClient(TestCase):
     def test_get_tags(self):
         self.assertEqual(
             (
-                IssueTag(
+                IssueTag.construct(
                     type="IssueTag",
                     id="6-0",
                     name="productivity",
                 ),
-                IssueTag(
+                IssueTag.construct(
                     type="IssueTag",
                     id="6-1",
                     name="tip",
                 ),
-                IssueTag(
+                IssueTag.construct(
                     type="IssueTag",
                     id="6-5",
                     name="Star",
@@ -346,28 +346,28 @@ class TestClient(TestCase):
     def test_get_users(self):
         self.assertEqual(
             (
-                User(
+                User.construct(
                     type="User",
                     id="1-17",
                     ring_id="c5d08431-dd52-4cdd-9911-7ec3a18ad117",
                     login="max.demo",
                     email="max@example.com",
                 ),
-                User(
+                User.construct(
                     type="User",
                     id="1-3",
                     ring_id="b0fea1e1-ed18-43f6-a99d-40044fb1dfb0",
                     login="support",
                     email="support@example.com",
                 ),
-                User(
+                User.construct(
                     type="User",
                     id="1-9",
                     ring_id="f19c93e1-833b-407b-a4de-7f9a3370aaf3",
                     login="sam",
                     email="sam@example.com",
                 ),
-                User(
+                User.construct(
                     type="User",
                     id="1-10",
                     ring_id="20e4e701-7e87-45f8-8492-c448600b7991",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,19 +7,25 @@ import requests_mock
 
 from youtrack_sdk.client import Client
 from youtrack_sdk.entities import (
+    CustomField,
     DateIssueCustomField,
     EnumBundleElement,
+    EnumProjectCustomField,
+    FieldType,
     Issue,
     IssueAttachment,
     IssueComment,
     IssueTag,
     Project,
     SimpleIssueCustomField,
+    SimpleProjectCustomField,
     SingleEnumIssueCustomField,
     SingleUserIssueCustomField,
     StateBundleElement,
     StateIssueCustomField,
+    StateProjectCustomField,
     User,
+    UserProjectCustomField,
 )
 
 
@@ -90,6 +96,16 @@ class TestClient(TestCase):
                             name="In Progress",
                             type="StateBundleElement",
                         ),
+                        project_custom_field=StateProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(
+                                    type="FieldType",
+                                    id="state[1]",
+                                ),
+                            ),
+                            type="StateProjectCustomField",
+                        ),
                     ),
                     SingleUserIssueCustomField(
                         id="111-8",
@@ -103,6 +119,13 @@ class TestClient(TestCase):
                             login="worker",
                             email="worker@example.com",
                         ),
+                        project_custom_field=UserProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(type="FieldType", id="user[1]"),
+                            ),
+                            type="UserProjectCustomField",
+                        ),
                     ),
                     SingleEnumIssueCustomField(
                         id="110-49",
@@ -113,42 +136,93 @@ class TestClient(TestCase):
                             name="Value One",
                             type="EnumBundleElement",
                         ),
+                        project_custom_field=EnumProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(type="FieldType", id="enum[1]"),
+                            ),
+                            type="EnumProjectCustomField",
+                        ),
                     ),
                     DateIssueCustomField(
                         id="145-34",
                         name="Due Date",
                         type="DateIssueCustomField",
                         value=date(2022, 2, 17),
+                        project_custom_field=SimpleProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(type="FieldType", id="date"),
+                            ),
+                        ),
                     ),
                     SimpleIssueCustomField(
                         id="145-35",
                         name="Started at",
                         type="SimpleIssueCustomField",
                         value=datetime(2021, 6, 11, 7, 32, 9, tzinfo=timezone.utc),
+                        project_custom_field=SimpleProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(
+                                    type="FieldType",
+                                    id="date and time",
+                                ),
+                            ),
+                            type="SimpleProjectCustomField",
+                        ),
                     ),
                     SimpleIssueCustomField(
                         id="145-36",
                         name="Multipass",
                         type="SimpleIssueCustomField",
-                        value="100-003-675",
+                        value="1623396729",
+                        project_custom_field=SimpleProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(type="FieldType", id="string"),
+                            ),
+                            type="SimpleProjectCustomField",
+                        ),
                     ),
-                    SimpleIssueCustomField(
+                    SimpleIssueCustomField.construct(
                         id="145-39",
                         name="Price",
                         type="SimpleIssueCustomField",
                         value=4003,
+                        project_custom_field=SimpleProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(type="FieldType", id="integer"),
+                            ),
+                            type="SimpleProjectCustomField",
+                        ),
                     ),
                     SimpleIssueCustomField(
                         id="145-37",
                         name="Multiplier",
                         type="SimpleIssueCustomField",
                         value=3.1412,
+                        project_custom_field=SimpleProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(type="FieldType", id="float"),
+                            ),
+                            type="SimpleProjectCustomField",
+                        ),
                     ),
                     SimpleIssueCustomField(
                         id="145-38",
                         name="Extra",
                         type="SimpleIssueCustomField",
                         value=None,
+                        project_custom_field=SimpleProjectCustomField.construct(
+                            field=CustomField.construct(
+                                type="CustomField",
+                                field_type=FieldType.construct(type="FieldType", id="string"),
+                            ),
+                            type="SimpleProjectCustomField",
+                        ),
                     ),
                 ],
             ),

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -41,7 +41,7 @@ class TestObjToDict(TestCase):
                 "shortName": "Demo",
                 "value": None,
             },
-            obj_to_dict(SimpleModel(short_name="Demo", value=None)),
+            obj_to_dict(SimpleModel.construct(short_name="Demo", value=None)),
         )
 
     def test_nested_model(self):
@@ -55,8 +55,8 @@ class TestObjToDict(TestCase):
                 },
             },
             obj_to_dict(
-                NestedModel(
-                    source=SimpleModel(short_name="Demo", value=None),
+                NestedModel.construct(
+                    source=SimpleModel.construct(short_name="Demo", value=None),
                 ),
             ),
         )
@@ -77,12 +77,12 @@ class TestObjToDict(TestCase):
                 ],
             },
             obj_to_dict(
-                NestedSequenceModel(
+                NestedSequenceModel.construct(
                     items=[
-                        NestedModel(),
-                        NestedModel(
-                            source=SimpleModel(short_name="Source", value=None),
-                            dest=SimpleModel(short_name="Dest", value=5),
+                        NestedModel.construct(),
+                        NestedModel.construct(
+                            source=SimpleModel.construct(short_name="Source", value=None),
+                            dest=SimpleModel.construct(short_name="Dest", value=5),
                         ),
                     ],
                 ),

--- a/youtrack_sdk/entities.py
+++ b/youtrack_sdk/entities.py
@@ -2,7 +2,9 @@ from datetime import date, datetime
 from typing import Literal, Optional, Sequence
 
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import Field
+from pydantic import Field, StrictFloat, StrictInt, StrictStr
+
+from .types import DateTime
 
 
 class BaseModel(PydanticBaseModel):
@@ -66,9 +68,83 @@ class UserGroup(BaseModel):
     ring_id: Optional[str] = Field(alias="ringId")
 
 
+class FieldType(BaseModel):
+    type: Literal["FieldType"] = Field(alias="$type", default="FieldType")
+    id: Optional[str]
+
+
+class CustomField(BaseModel):
+    type: Literal["CustomField"] = Field(alias="$type", default="CustomField")
+    field_type: Optional[FieldType] = Field(alias="fieldType")
+
+
+class ProjectCustomField(BaseModel):
+    field: Optional[CustomField]
+
+
+class GroupProjectCustomField(ProjectCustomField):
+    type: Literal["GroupProjectCustomField"] = Field(alias="$type", default="GroupProjectCustomField")
+
+
+class BundleProjectCustomField(ProjectCustomField):
+    type: Literal["BundleProjectCustomField"] = Field(alias="$type", default="BundleProjectCustomField")
+
+
+class BuildProjectCustomField(BundleProjectCustomField):
+    type: Literal["BuildProjectCustomField"] = Field(alias="$type", default="BuildProjectCustomField")
+
+
+class EnumProjectCustomField(BundleProjectCustomField):
+    type: Literal["EnumProjectCustomField"] = Field(alias="$type", default="EnumProjectCustomField")
+
+
+class OwnedProjectCustomField(BundleProjectCustomField):
+    type: Literal["OwnedProjectCustomField"] = Field(alias="$type", default="OwnedProjectCustomField")
+
+
+class StateProjectCustomField(BundleProjectCustomField):
+    type: Literal["StateProjectCustomField"] = Field(alias="$type", default="StateProjectCustomField")
+
+
+class UserProjectCustomField(BundleProjectCustomField):
+    type: Literal["UserProjectCustomField"] = Field(alias="$type", default="UserProjectCustomField")
+
+
+class VersionProjectCustomField(BundleProjectCustomField):
+    type: Literal["VersionProjectCustomField"] = Field(alias="$type", default="VersionProjectCustomField")
+
+
+class SimpleProjectCustomField(ProjectCustomField):
+    type: Literal["SimpleProjectCustomField"] = Field(alias="$type", default="SimpleProjectCustomField")
+
+
+class TextProjectCustomField(SimpleProjectCustomField):
+    type: Literal["TextProjectCustomField"] = Field(alias="$type", default="TextProjectCustomField")
+
+
+class PeriodProjectCustomField(ProjectCustomField):
+    type: Literal["PeriodProjectCustomField"] = Field(alias="$type", default="PeriodProjectCustomField")
+
+
+ProjectCustomFieldType = (
+    GroupProjectCustomField
+    | BundleProjectCustomField
+    | BuildProjectCustomField
+    | EnumProjectCustomField
+    | OwnedProjectCustomField
+    | StateProjectCustomField
+    | UserProjectCustomField
+    | VersionProjectCustomField
+    | SimpleProjectCustomField
+    | TextProjectCustomField
+    | PeriodProjectCustomField
+)
+
+
 class IssueCustomField(BaseModel):
     id: Optional[str]
     name: Optional[str]
+    project_custom_field: Optional[ProjectCustomFieldType] = Field(alias="projectCustomField")
 
 
 class TextIssueCustomField(IssueCustomField):
@@ -78,7 +154,7 @@ class TextIssueCustomField(IssueCustomField):
 
 class SimpleIssueCustomField(IssueCustomField):
     type: Literal["SimpleIssueCustomField"] = Field(alias="$type", default="SimpleIssueCustomField")
-    value: Optional[datetime | str | int | float]
+    value: Optional[DateTime | StrictStr | StrictInt | StrictFloat]
 
 
 class DateIssueCustomField(SimpleIssueCustomField):

--- a/youtrack_sdk/types.py
+++ b/youtrack_sdk/types.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from pydantic.datetime_parse import from_unix_seconds
+from pydantic.errors import PydanticValueError
+
+
+class StrictIntError(PydanticValueError):
+    msg_template = "value is not a valid integer"
+
+
+class IncompatibleFieldTypeError(PydanticValueError):
+    msg_template = "incompatible field type"
+
+
+class DateTime(datetime):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value, values):
+        if (project_custom_field := values.get("project_custom_field")) and (
+            project_custom_field.field.field_type.id != "date and time"
+        ):
+            raise IncompatibleFieldTypeError
+
+        if isinstance(value, datetime):
+            return value
+
+        if not isinstance(value, int):
+            raise StrictIntError
+
+        return from_unix_seconds(value)


### PR DESCRIPTION
[Simple custom field](https://www.jetbrains.com/help/youtrack/devportal/api-entity-SimpleIssueCustomField.html) in YouTrack can be one of the four types: datetime, integer, string or float. In some cases, field can contain a string value that can be recognized by mistake as a Unix timestamp (e.g. `1623396729`, see documentation on how pydantic [converts values to datetime](https://pydantic-docs.helpmanual.io/usage/types/#datetime-types) for details of this implementation). To prevent this behavior, I added a check before converting value to datetime by implementing a custom pydantic type. I also replaced `str`, `int` and `float` types in `SimpleIssueCustomField` with their strict versions.

During testing I realized that we use wrong way to instantiate pydantic models in tests, which leads to invalid results in the tests. After updating the tests, I found out that it's not possible anymore to use integer type of the custom field. Because in case of any value it will be converted to a datetime object. The problem is that YouTrack API has a separate type for [date field](https://www.jetbrains.com/help/youtrack/devportal/api-entity-DateIssueCustomField.html), but it doesn't have a separate type for datetime. The only way to get the field type is to access `projectCustomField` which is not yet implemented in our SDK.
```json
{
  "value": 919080000000,
  "isUpdatable": true,
  "projectCustomField": {
    "ordinal": 14,
    "emptyFieldText": "No date",
    "canBeEmpty": true,
    "isPublic": true,
    "field": {
      "ordinal": 35,
      "localizedName": null,
      "fieldType": {
        "isMultiValue": false,
        "valueType": "date",
        "$type": "FieldType"
      },
      "name": "Date",
      "id": "93-34",
      "$type": "CustomField"
    },
    "id": "145-56",
    "$type": "SimpleProjectCustomField"
  },
  "name": "Date",
  "id": "145-56",
  "$type": "DateIssueCustomField"
}
```
But at the moment I don't know an easy way how to integrate it into our custom fields validation.