### PR TITLE
feat(sdk): upgrade to Pydantic v2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -27,36 +27,33 @@ files = [
 
 [[package]]
 name = "black"
-version = "23.3.0"
+version = "23.7.0"
 description = "The uncompromising code formatter."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
-    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
-    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
-    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
-    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
-    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
-    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
-    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
-    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
-    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
-    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
-    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
-    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
-    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
-    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
-    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
-    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
-    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:5c4bc552ab52f6c1c506ccae05681fab58c3f72d59ae6e6639e8885e94fe2587"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:552513d5cd5694590d7ef6f46e1767a4df9af168d449ff767b13b084c020e63f"},
+    {file = "black-23.7.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:86cee259349b4448adb4ef9b204bb4467aae74a386bce85d56ba4f5dc0da27be"},
+    {file = "black-23.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:501387a9edcb75d7ae8a4412bb8749900386eaef258f1aefab18adddea1936bc"},
+    {file = "black-23.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb074d8b213749fa1d077d630db0d5f8cc3b2ae63587ad4116e8a436e9bbe995"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b5b0ee6d96b345a8b420100b7d71ebfdd19fab5e8301aff48ec270042cd40ac2"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:893695a76b140881531062d48476ebe4a48f5d1e9388177e175d76234ca247cd"},
+    {file = "black-23.7.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c333286dc3ddca6fdff74670b911cccedacb4ef0a60b34e491b8a67c833b343a"},
+    {file = "black-23.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:831d8f54c3a8c8cf55f64d0422ee875eecac26f5f649fb6c1df65316b67c8926"},
+    {file = "black-23.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:7f3bf2dec7d541b4619b8ce526bda74a6b0bffc480a163fed32eb8b3c9aed8ad"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:f9062af71c59c004cd519e2fb8f5d25d39e46d3af011b41ab43b9c74e27e236f"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:01ede61aac8c154b55f35301fac3e730baf0c9cf8120f65a9cd61a81cfb4a0c3"},
+    {file = "black-23.7.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:327a8c2550ddc573b51e2c352adb88143464bb9d92c10416feb86b0f5aee5ff6"},
+    {file = "black-23.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1c6022b86f83b632d06f2b02774134def5d4d4f1dac8bef16d90cda18ba28a"},
+    {file = "black-23.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:27eb7a0c71604d5de083757fbdb245b1a4fae60e9596514c6ec497eb63f95320"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:8417dbd2f57b5701492cd46edcecc4f9208dc75529bcf76c514864e48da867d9"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:47e56d83aad53ca140da0af87678fb38e44fd6bc0af71eebab2d1f59b1acf1d3"},
+    {file = "black-23.7.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:25cc308838fe71f7065df53aedd20327969d05671bac95b38fdf37ebe70ac087"},
+    {file = "black-23.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:642496b675095d423f9b8448243336f8ec71c9d4d57ec17bf795b67f08132a91"},
+    {file = "black-23.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:ad0014efc7acf0bd745792bd0d8857413652979200ab924fbf239062adc12491"},
+    {file = "black-23.7.0-py3-none-any.whl", hash = "sha256:9fd59d418c60c0348505f2ddf9609c1e1de8e7493eab96198fc89d9f865e7a96"},
+    {file = "black-23.7.0.tar.gz", hash = "sha256:022a582720b0d9480ed82576c920a8c1dde97cc38ff11d8d8859b3bd6ca9eedb"},
 ]
 
 [package.dependencies]
@@ -74,108 +71,108 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.1.0"
+version = "3.2.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "charset-normalizer-3.1.0.tar.gz", hash = "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-win32.whl", hash = "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448"},
-    {file = "charset_normalizer-3.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-win32.whl", hash = "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909"},
-    {file = "charset_normalizer-3.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-win32.whl", hash = "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974"},
-    {file = "charset_normalizer-3.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-win32.whl", hash = "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0"},
-    {file = "charset_normalizer-3.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-win32.whl", hash = "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1"},
-    {file = "charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b"},
-    {file = "charset_normalizer-3.1.0-py3-none-any.whl", hash = "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d"},
+    {file = "charset-normalizer-3.2.0.tar.gz", hash = "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win32.whl", hash = "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96"},
+    {file = "charset_normalizer-3.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win32.whl", hash = "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1"},
+    {file = "charset_normalizer-3.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win32.whl", hash = "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1"},
+    {file = "charset_normalizer-3.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win32.whl", hash = "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706"},
+    {file = "charset_normalizer-3.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win32.whl", hash = "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9"},
+    {file = "charset_normalizer-3.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80"},
+    {file = "charset_normalizer-3.2.0-py3-none-any.whl", hash = "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6"},
 ]
 
 [[package]]
 name = "click"
-version = "8.1.3"
+version = "8.1.6"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
+    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
 ]
 
 [package.dependencies]
@@ -428,13 +425,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.8.0"
+version = "3.9.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
-    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
+    {file = "platformdirs-3.9.1-py3-none-any.whl", hash = "sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f"},
+    {file = "platformdirs-3.9.1.tar.gz", hash = "sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421"},
 ]
 
 [package.extras]
@@ -469,18 +466,18 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.0.1"
+version = "2.1.1"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic-2.0.1-py3-none-any.whl", hash = "sha256:7a3e3b1d0384eaa313f0810cffa475d6849794a9ae5768989518114771cb9241"},
-    {file = "pydantic-2.0.1.tar.gz", hash = "sha256:041945a6c75f2451a343674ec7d220cb7e207884fb06aaf2c16b6d0bfaf2bc39"},
+    {file = "pydantic-2.1.1-py3-none-any.whl", hash = "sha256:43bdbf359d6304c57afda15c2b95797295b702948082d4c23851ce752f21da70"},
+    {file = "pydantic-2.1.1.tar.gz", hash = "sha256:22d63db5ce4831afd16e7c58b3192d3faf8f79154980d9397d9867254310ba4b"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.4.0"
-pydantic-core = "2.0.2"
+pydantic-core = "2.4.0"
 typing-extensions = ">=4.6.1"
 
 [package.extras]
@@ -488,92 +485,112 @@ email = ["email-validator (>=2.0.0)"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.0.2"
+version = "2.4.0"
 description = ""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic_core-2.0.2-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:fb3d452def28f86fcec749659fea183650c23aa46ae4d8a9996463a1793587b5"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:13ff737b9dbda2175bf2d59f8c8d0989b9a331a50d1eb8b7e6e0fdc264af3e93"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ccade95f48f47c898632d8dd995704924fce0f99deb7fd4f24348792769abec"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:433b13fa81a06589dae5198dd285c5621714d4b6d75da058ba8347f8c36cb796"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-manylinux_2_24_armv7l.whl", hash = "sha256:a5576ad07f480a21b38fff2e15d2c90ab3b18f36692065235df237711b402afd"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-manylinux_2_24_ppc64le.whl", hash = "sha256:15cb57ca61280eca0b8d721d3629871ab239954c4cec049acf9354405836f341"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-manylinux_2_24_s390x.whl", hash = "sha256:e28d86253cdc638d084751bcc1217944370c567722d377c1364fd1433d0a41f9"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b8b622793e7b7ecb25916f30e91d49424a1f10db08aa151ff7eabd29039ae15c"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0b435c029f00b402df3ab19c07b6d8a2e26a5abbb15117b93c457e3ed40237d7"},
-    {file = "pydantic_core-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:89d271bae5b6e43936e0365b387d317bd309c5e7c5645b7608b939410fb86968"},
-    {file = "pydantic_core-2.0.2-cp310-none-win32.whl", hash = "sha256:5598f9d4e063e9a64233792dc0f8a0fab8036fb66d25cfc356649667a6542bfb"},
-    {file = "pydantic_core-2.0.2-cp310-none-win_amd64.whl", hash = "sha256:c17fd1d0fef829b364fbbd06aad286b7a73b7b93a46f1967aff1c8f78e5a250a"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:e7d8df9e29ecc2930d27fccde99ae86c1dfc42c1f92e81715df2a7dc1f7f466e"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27338dfc0a474645d6fe2139b30f006a381f7926e80485370361d7e882a60034"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbe2b50a4c3bcc9962449eea1c73d2e509a4e3a96df38511b898eea768fde4a4"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:196c90996542db0151265a1fe7b32d20f5d66fc00ec12ef6f10dd6a3be5aa05f"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-manylinux_2_24_armv7l.whl", hash = "sha256:75bbf0045f52696aa317b38e67ef5c80a15b7aab572956df2c6fb44f3f4c8b3e"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-manylinux_2_24_ppc64le.whl", hash = "sha256:fb6551210cef7423d68eaaeab60a9445e17edd33d251b2ab6c783afce9811df8"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-manylinux_2_24_s390x.whl", hash = "sha256:8ebb72dec9eefc3eb419de764d0510bbaa08e4db2b4a997576cce338a5f93c97"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc901bb6ffe6d983903242dd7495660161b8901307c5280534fee3b0a90f98e6"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4cd3178131bb7d0d3df947587d76cf9d1ab4318fe45e8ad18dafba3b1f0cda6d"},
-    {file = "pydantic_core-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc4cb821dc67963463f8d8be6dca8933210d050009b32f683d02444a3d5f1e02"},
-    {file = "pydantic_core-2.0.2-cp311-none-win32.whl", hash = "sha256:9cf009170f5f93c3dad4c4f73d827541d4bb7099cf69216c091d8cdd33867255"},
-    {file = "pydantic_core-2.0.2-cp311-none-win_amd64.whl", hash = "sha256:4ed79de66b4b9acdd613c48befe4afcbee05f6153d793df6922ffc392f46720e"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:26f948f36f679d84cb1b66be40775a09275579e9bba01178dbe9b8231dcbf691"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:c815a0908065dd8eae0740e55063fcf730c5ef86edf6210ecd53ace3a85c9911"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d088fdc5cc709a715cf9f49e698a5690cc00616d3379e55d07423e628a21a097"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e63f360661847422423410ebe755258aefad8bd67e9ac516eb1d02a90bdf788"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-manylinux_2_24_armv7l.whl", hash = "sha256:0cec91249c78b5697294b01e66acb819433f4111ae640b7300dd5508a522342e"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-manylinux_2_24_ppc64le.whl", hash = "sha256:27b3eb357a801519dcf42f6c88a3a37e140cf29be21dd5dc152cfc9fa44c34d2"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-manylinux_2_24_s390x.whl", hash = "sha256:038876cd2dfc1319e0256995ee74cdd90df2ce03bc6060d5eaee01cc78cf3dae"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2f45943b592070fd744660fc8e31a010ae78a6e91f8e6431c07f6dce022eb03f"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c44ec0439fac342f773cd848b20cf28cc376670369a6d42845d180f18f2671e3"},
-    {file = "pydantic_core-2.0.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5465264bbc535a8650a3806ae5bd07e2691428004a52c961281eadce519c60cc"},
-    {file = "pydantic_core-2.0.2-cp37-none-win32.whl", hash = "sha256:26722063f83c3c4f596adc1eadfa03249afa38e75f3516684de9b57e15d07346"},
-    {file = "pydantic_core-2.0.2-cp37-none-win_amd64.whl", hash = "sha256:638b474da73e71079f39a80e4d70196853c2d2fc98c3d425ce3a3ae738e2245f"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:bd9587083b48ec822960a8047249c8119e82749bdf96cecc2e1975322ccb1405"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2e02faa4a5e9bd1d7cb4b056c911826f67c4bf298979f89f07c3f2446cd0cf86"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24a46c1fd078f3dc7d075200e48b219ed0876f81753201a2d97ad09165d5383f"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8136e89efab6f8399bdaf5254758db37049eeaa2f39645ce999aa5162392be28"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-manylinux_2_24_armv7l.whl", hash = "sha256:07f02b4a474fa89be0bb0b0c42eb605d2a9c8fe11ea7f82fb754060fd0a5ac33"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-manylinux_2_24_ppc64le.whl", hash = "sha256:e5bcca875379fab98c7b8b4ddfe932844d9ac7dc0a850c5afa414d17988aed93"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-manylinux_2_24_s390x.whl", hash = "sha256:9d65b216c0e55414330e46c272896d4858a30d53310aa6e58520e2fc3d122deb"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:51defb4826a28644034915ec5f5a5d3be2d56b683891343d53dfca936c634326"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4277e1941faa5c59fddfc49dae98dc94c16288bc9a09c7b17599c8388aeadcb5"},
-    {file = "pydantic_core-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c7a2c290d6abff5abf6566aa5ea07342e74af42f4defb1f33b3b3d9e7ff1c61f"},
-    {file = "pydantic_core-2.0.2-cp38-none-win32.whl", hash = "sha256:21dcb4f0168f3877cb487dc18362b78bea1e877bcb9c6b4af7563d5e00508cc0"},
-    {file = "pydantic_core-2.0.2-cp38-none-win_amd64.whl", hash = "sha256:1005ab00b3f39b044408a357b41b66709b6eca17092d2713ee4b79d85a86457b"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:210ed18f2c438b282a2d5710c07dfa42b8de63647f650c742ecd18a4e02a0618"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7d6a9e510ae4ea02db709472102fa7b59d48441a6c0419a7d21d0b96672a469"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d5cece19558a3490ace346d70322766e670c51ce98ab9bea3e85efba6c00424"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b73e646fda49a5b503f7484a8797a36697b28b5be3adb597460f1d3d337fb82"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-manylinux_2_24_armv7l.whl", hash = "sha256:7e5264ed7727ab09c410a98c47430c2ab426c2edb9a7b613ca1d785dd3506b7d"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-manylinux_2_24_ppc64le.whl", hash = "sha256:d2db12d32b3b83c3d1a2044f9ba31aca9a8224c7eb15d949bdae3e826ee8c6ec"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-manylinux_2_24_s390x.whl", hash = "sha256:3127bd2a5764ed08529ca03f8b9e486d347fb2f604cd8333ae7e55a1693073af"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c9f856a5c8938f2e0c7bb337f09d5212afd390627929c53e5f0c5944c99732fc"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f8119485a74487780fecf8c03cce66a2fb13da2e68f4219af7aca9d0eb8ff64d"},
-    {file = "pydantic_core-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e931731368ea56f1787fc408757708348639ef2aa1f01e3d483ad1574780b92"},
-    {file = "pydantic_core-2.0.2-cp39-none-win32.whl", hash = "sha256:1fa900836d3995ecf34b48f4687a7908b5de85f194e534a7f3a88bfeaee7e25b"},
-    {file = "pydantic_core-2.0.2-cp39-none-win_amd64.whl", hash = "sha256:e6973ccb84a532e35b6a9f7f8d6024688186d950278700d408836219aa5b6164"},
-    {file = "pydantic_core-2.0.2-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:ca833856df881b9809747131c38bf7b6af7262ab2c77a2834b9e9d64cf43ab4e"},
-    {file = "pydantic_core-2.0.2-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a349f816319ac85759a19ccb0e93992fe77f8e1961a389cd15c3b5c6098bcabd"},
-    {file = "pydantic_core-2.0.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b67ede74b43598feb405a628c83087b3df1066a388ab060cdd5333d061ecf3f5"},
-    {file = "pydantic_core-2.0.2-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bf4bb512eb302acbef4774f65a9ae83edfb283055de7b18b9656b8fda0869652"},
-    {file = "pydantic_core-2.0.2-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:fede91ea67570eb296d4ae88aecb9c51a46cdccb35a388dba759183ba84c61d6"},
-    {file = "pydantic_core-2.0.2-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:7d1c453a36e69ddd4ea47a8e5426a63fdcb731d18122571fbdfda23b07ad28b1"},
-    {file = "pydantic_core-2.0.2-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:751e6deca13d89bc5ffc4684ac8a4ea08c6c0ac8dfe12cc5d6927f249879131d"},
-    {file = "pydantic_core-2.0.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:312263dea8116f68972c41c53c0a5b5bf9f7732e7bdc978acb847ed7c9fc8207"},
-    {file = "pydantic_core-2.0.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17334cef22055154b7faf7254cc0bf86fea34a7343225b8c6d2d0e54f3533048"},
-    {file = "pydantic_core-2.0.2-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:84f1eb4d23a37f77b20dabffe7d5971c6c8eea78bd977fcd2007704ccb540230"},
-    {file = "pydantic_core-2.0.2-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:d4677520ade160805ad55a6418db7beea9dea34f0a091da1f0bcf09c66091b54"},
-    {file = "pydantic_core-2.0.2-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:c63bb44c2af1250fcf6e8447b0fda17f09d28e4677910f5bc1328881ae2c527e"},
-    {file = "pydantic_core-2.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:2c351a141124c216fe4a0119ef2fa5bc70eec710e59cdd79346475b3f78d15e9"},
-    {file = "pydantic_core-2.0.2-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:f295db65d4de14c0b46168a6db73be34b8fe4e3e2699a9c574b37412d0dd2a41"},
-    {file = "pydantic_core-2.0.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c344dd1c345b2206515edaba0e0bf4aa2b1c456822f3ac9bc0d9f7fc971a8934"},
-    {file = "pydantic_core-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31f95633f6a3ddc8e0b850157ac0cedb8ccacbe4349310b4be6d724860d8f5c0"},
-    {file = "pydantic_core-2.0.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c587db8f31a1c3270991945c20c2ace289fbfa7cf2d533f67f47e95c9ead83e"},
-    {file = "pydantic_core-2.0.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a10ce991b6986c91fdf100611d97f76b2950a1d2c2e72be0484565bf95b03767"},
-    {file = "pydantic_core-2.0.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:aab82425d10bf0624e4a7ac902eed33adae413e827b53d82ae131a10c3130208"},
-    {file = "pydantic_core-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:b024721a940a3311328d50f7cc3d9a7aced0f5ee1fd30c0fa7cbbc542ec3a55c"},
-    {file = "pydantic_core-2.0.2.tar.gz", hash = "sha256:996ffb7ae3c8cb7506a58dae52bbf13a7bbbfce6c3110a2b44c20d2587e57b9b"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:2ca4687dd996bde7f3c420def450797feeb20dcee2b9687023e3323c73fc14a2"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:782fced7d61469fd1231b184a80e4f2fa7ad54cd7173834651a453f96f29d673"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6213b471b68146af97b8551294e59e7392c2117e28ffad9c557c65087f4baee3"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63797499a219d8e81eb4e0c42222d0a4c8ec896f5c76751d4258af95de41fdf1"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-manylinux_2_24_armv7l.whl", hash = "sha256:0455876d575a35defc4da7e0a199596d6c773e20d3d42fa1fc29f6aa640369ed"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-manylinux_2_24_ppc64le.whl", hash = "sha256:8c938c96294d983dcf419b54dba2d21056959c22911d41788efbf949a29ae30d"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-manylinux_2_24_s390x.whl", hash = "sha256:878a5017d93e776c379af4e7b20f173c82594d94fa073059bcc546789ad50bf8"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:69159afc2f2dc43285725f16143bc5df3c853bc1cb7df6021fce7ef1c69e8171"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:54df7df399b777c1fd144f541c95d351b3aa110535a6810a6a569905d106b6f3"},
+    {file = "pydantic_core-2.4.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e412607ca89a0ced10758dfb8f9adcc365ce4c1c377e637c01989a75e9a9ec8a"},
+    {file = "pydantic_core-2.4.0-cp310-none-win32.whl", hash = "sha256:853f103e2b9a58832fdd08a587a51de8b552ae90e1a5d167f316b7eabf8d7dde"},
+    {file = "pydantic_core-2.4.0-cp310-none-win_amd64.whl", hash = "sha256:3ba2c9c94a9176f6321a879c8b864d7c5b12d34f549a4c216c72ce213d7d953c"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:a8b7acd04896e8f161e1500dc5f218017db05c1d322f054e89cbd089ce5d0071"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:16468bd074fa4567592d3255bf25528ed41e6b616d69bf07096bdb5b66f947d1"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cba5ad5eef02c86a1f3da00544cbc59a510d596b27566479a7cd4d91c6187a11"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7206e41e04b443016e930e01685bab7a308113c0b251b3f906942c8d4b48fcb"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-manylinux_2_24_armv7l.whl", hash = "sha256:c1375025f0bfc9155286ebae8eecc65e33e494c90025cda69e247c3ccd2bab00"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-manylinux_2_24_ppc64le.whl", hash = "sha256:3534118289e33130ed3f1cc487002e8d09b9f359be48b02e9cd3de58ce58fba9"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-manylinux_2_24_s390x.whl", hash = "sha256:94d2b36a74623caab262bf95f0e365c2c058396082bd9d6a9e825657d0c1e7fa"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af24ad4fbaa5e4a2000beae0c3b7fd1c78d7819ab90f9370a1cfd8998e3f8a3c"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bf10963d8aed8bbe0165b41797c9463d4c5c8788ae6a77c68427569be6bead41"},
+    {file = "pydantic_core-2.4.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:68199ada7c310ddb8c76efbb606a0de656b40899388a7498954f423e03fc38be"},
+    {file = "pydantic_core-2.4.0-cp311-none-win32.whl", hash = "sha256:6f855bcc96ed3dd56da7373cfcc9dcbabbc2073cac7f65c185772d08884790ce"},
+    {file = "pydantic_core-2.4.0-cp311-none-win_amd64.whl", hash = "sha256:de39eb3bab93a99ddda1ac1b9aa331b944d8bcc4aa9141148f7fd8ee0299dafc"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:f773b39780323a0499b53ebd91a28ad11cde6705605d98d999dfa08624caf064"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a297c0d6c61963c5c3726840677b798ca5b7dfc71bc9c02b9a4af11d23236008"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:546064c55264156b973b5e65e5fafbe5e62390902ce3cf6b4005765505e8ff56"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36ba9e728588588f0196deaf6751b9222492331b5552f865a8ff120869d372e0"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-manylinux_2_24_armv7l.whl", hash = "sha256:57a53a75010c635b3ad6499e7721eaa3b450e03f6862afe2dbef9c8f66e46ec8"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-manylinux_2_24_ppc64le.whl", hash = "sha256:4b262bbc13022f2097c48a21adcc360a81d83dc1d854c11b94953cd46d7d3c07"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-manylinux_2_24_s390x.whl", hash = "sha256:01947ad728f426fa07fcb26457ebf90ce29320259938414bc0edd1476e75addb"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b2799c2eaf182769889761d4fb4d78b82bc47dae833799fedbf69fc7de306faa"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:a08fd490ba36d1fbb2cd5dcdcfb9f3892deb93bd53456724389135712b5fc735"},
+    {file = "pydantic_core-2.4.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1e8a7c62d15a5c4b307271e4252d76ebb981d6251c6ecea4daf203ef0179ea4f"},
+    {file = "pydantic_core-2.4.0-cp312-none-win32.whl", hash = "sha256:9206c14a67c38de7b916e486ae280017cf394fa4b1aa95cfe88621a4e1d79725"},
+    {file = "pydantic_core-2.4.0-cp312-none-win_amd64.whl", hash = "sha256:884235507549a6b2d3c4113fb1877ae263109e787d9e0eb25c35982ab28d0399"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:4cbe929efa77a806e8f1a97793f2dc3ea3475ae21a9ed0f37c21320fe93f6f50"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:9137289de8fe845c246a8c3482dd0cb40338846ba683756d8f489a4bd8fddcae"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5d8e764b5646623e57575f624f8ebb8f7a9f7fd1fae682ef87869ca5fec8dcf"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fba0aff4c407d0274e43697e785bcac155ad962be57518d1c711f45e72da70f"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-manylinux_2_24_armv7l.whl", hash = "sha256:30527d173e826f2f7651f91c821e337073df1555e3b5a0b7b1e2c39e26e50678"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-manylinux_2_24_ppc64le.whl", hash = "sha256:bd7d1dde70ff3e09e4bc7a1cbb91a7a538add291bfd5b3e70ef1e7b45192440f"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-manylinux_2_24_s390x.whl", hash = "sha256:72f1216ca8cef7b8adacd4c4c6b89c3b0c4f97503197f5284c80f36d6e4edd30"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b013c7861a7c7bfcec48fd709513fea6f9f31727e7a0a93ca0dd12e056740717"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:478f5f6d7e32bd4a04d102160efb2d389432ecf095fe87c555c0a6fc4adfc1a4"},
+    {file = "pydantic_core-2.4.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d9610b47b5fe4aacbbba6a9cb5f12cbe864eec99dbfed5710bd32ef5dd8a5d5b"},
+    {file = "pydantic_core-2.4.0-cp37-none-win32.whl", hash = "sha256:ff246c0111076c8022f9ba325c294f2cb5983403506989253e04dbae565e019b"},
+    {file = "pydantic_core-2.4.0-cp37-none-win_amd64.whl", hash = "sha256:d0c2b713464a8e263a243ae7980d81ce2de5ac59a9f798a282e44350b42dc516"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:12ef6838245569fd60a179fade81ca4b90ae2fa0ef355d616f519f7bb27582db"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49db206eb8fdc4b4f30e6e3e410584146d813c151928f94ec0db06c4f2595538"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a507d7fa44688bbac76af6521e488b3da93de155b9cba6f2c9b7833ce243d59"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe18407a4d000c568182ce5388bbbedeb099896904e43fc14eee76cfae6dec5"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-manylinux_2_24_armv7l.whl", hash = "sha256:fa8e48001b39d54d97d7b380a0669fa99fc0feeb972e35a2d677ba59164a9a22"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-manylinux_2_24_ppc64le.whl", hash = "sha256:394f12a2671ff8c4dfa2e85be6c08be0651ad85bc1e6aa9c77c21671baaf28cd"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-manylinux_2_24_s390x.whl", hash = "sha256:2f9ea0355f90db2a76af530245fa42f04d98f752a1236ed7c6809ec484560d5b"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:61d4e713f467abcdd59b47665d488bb898ad3dd47ce7446522a50e0cbd8e8279"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:453862ab268f6326b01f067ed89cb3a527d34dc46f6f4eeec46a15bbc706d0da"},
+    {file = "pydantic_core-2.4.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:56a85fa0dab1567bd0cac10f0c3837b03e8a0d939e6a8061a3a420acd97e9421"},
+    {file = "pydantic_core-2.4.0-cp38-none-win32.whl", hash = "sha256:0d726108c1c0380b88b6dd4db559f0280e0ceda9e077f46ff90bc85cd4d03e77"},
+    {file = "pydantic_core-2.4.0-cp38-none-win_amd64.whl", hash = "sha256:047580388644c473b934d27849f8ed8dbe45df0adb72104e78b543e13bf69762"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:867d3eea954bea807cabba83cfc939c889a18576d66d197c60025b15269d7cc0"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:664402ef0c238a7f8a46efb101789d5f2275600fb18114446efec83cfadb5b66"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64e8012ad60a5f0da09ed48725e6e923d1be25f2f091a640af6079f874663813"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac2b680de398f293b68183317432b3d67ab3faeba216aec18de0c395cb5e3060"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-manylinux_2_24_armv7l.whl", hash = "sha256:8efc1be43b036c2b6bcfb1451df24ee0ddcf69c31351003daf2699ed93f5687b"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-manylinux_2_24_ppc64le.whl", hash = "sha256:d93aedbc4614cc21b9ab0d0c4ccd7143354c1f7cffbbe96ae5216ad21d1b21b5"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-manylinux_2_24_s390x.whl", hash = "sha256:af788b64e13d52fc3600a68b16d31fa8d8573e3ff2fc9a38f8a60b8d94d1f012"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:97c6349c81cee2e69ef59eba6e6c08c5936e6b01c2d50b9e4ac152217845ae09"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cc086ddb6dc654a15deeed1d1f2bcb1cb924ebd70df9dca738af19f64229b06c"},
+    {file = "pydantic_core-2.4.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e953353180bec330c3b830891d260b6f8e576e2d18db3c78d314e56bb2276066"},
+    {file = "pydantic_core-2.4.0-cp39-none-win32.whl", hash = "sha256:6feb4b64d11d5420e517910d60a907d08d846cacaf4e029668725cd21d16743c"},
+    {file = "pydantic_core-2.4.0-cp39-none-win_amd64.whl", hash = "sha256:153a61ac4030fa019b70b31fb7986461119230d3ba0ab661c757cfea652f4332"},
+    {file = "pydantic_core-2.4.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:3fcf529382b282a30b466bd7af05be28e22aa620e016135ac414f14e1ee6b9e1"},
+    {file = "pydantic_core-2.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2edef05b63d82568b877002dc4cb5cc18f8929b59077120192df1e03e0c633f8"},
+    {file = "pydantic_core-2.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da055a1b0bfa8041bb2ff586b2cb0353ed03944a3472186a02cc44a557a0e661"},
+    {file = "pydantic_core-2.4.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:77dadc764cf7c5405e04866181c5bd94a447372a9763e473abb63d1dfe9b7387"},
+    {file = "pydantic_core-2.4.0-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a4ea23b07f29487a7bef2a869f68c7ee0e05424d81375ce3d3de829314c6b5ec"},
+    {file = "pydantic_core-2.4.0-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:382f0baa044d674ad59455a5eff83d7965572b745cc72df35c52c2ce8c731d37"},
+    {file = "pydantic_core-2.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:08f89697625e453421401c7f661b9d1eb4c9e4c0a12fd256eeb55b06994ac6af"},
+    {file = "pydantic_core-2.4.0-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:43a405ce520b45941df9ff55d0cd09762017756a7b413bbad3a6e8178e64a2c2"},
+    {file = "pydantic_core-2.4.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:584a7a818c84767af16ce8bda5d4f7fedb37d3d231fc89928a192f567e4ef685"},
+    {file = "pydantic_core-2.4.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04922fea7b13cd480586fa106345fe06e43220b8327358873c22d8dfa7a711c7"},
+    {file = "pydantic_core-2.4.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:17156abac20a9feed10feec867fddd91a80819a485b0107fe61f09f2117fe5f3"},
+    {file = "pydantic_core-2.4.0-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:4e562cc63b04636cde361fd47569162f1daa94c759220ff202a8129902229114"},
+    {file = "pydantic_core-2.4.0-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:90f3785146f701e053bb6b9e8f53acce2c919aca91df88bd4975be0cb926eb41"},
+    {file = "pydantic_core-2.4.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:e40b1e97edd3dc127aa53d8a5e539a3d0c227d71574d3f9ac1af02d58218a122"},
+    {file = "pydantic_core-2.4.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:b27f3e67f6e031f6620655741b7d0d6bebea8b25d415924b3e8bfef2dd7bd841"},
+    {file = "pydantic_core-2.4.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be86c2eb12fb0f846262ace9d8f032dc6978b8cb26a058920ecb723dbcb87d05"},
+    {file = "pydantic_core-2.4.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4665f7ed345012a8d2eddf4203ef145f5f56a291d010382d235b94e91813f88a"},
+    {file = "pydantic_core-2.4.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:79262be5a292d1df060f29b9a7cdd66934801f987a817632d7552534a172709a"},
+    {file = "pydantic_core-2.4.0-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:5fd905a69ac74eaba5041e21a1e8b1a479dab2b41c93bdcc4c1cede3c12a8d86"},
+    {file = "pydantic_core-2.4.0-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:2ad538b7e07343001934417cdc8584623b4d8823c5b8b258e75ec8d327cec969"},
+    {file = "pydantic_core-2.4.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:dd2429f7635ad4857b5881503f9c310be7761dc681c467a9d27787b674d1250a"},
+    {file = "pydantic_core-2.4.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:efff8b6761a1f6e45cebd1b7a6406eb2723d2d5710ff0d1b624fe11313693989"},
+    {file = "pydantic_core-2.4.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a1e0352558cd7ccc014ffe818c7d87b15ec6145875e2cc5fa4bb7351a1033d"},
+    {file = "pydantic_core-2.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a027f41c5008571314861744d83aff75a34cf3a07022e0be32b214a5bc93f7f1"},
+    {file = "pydantic_core-2.4.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1927f0e15d190f11f0b8344373731e28fd774c6d676d8a6cfadc95c77214a48b"},
+    {file = "pydantic_core-2.4.0-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:7aa82d483d5fb867d4fb10a138ffd57b0f1644e99f2f4f336e48790ada9ada5e"},
+    {file = "pydantic_core-2.4.0-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b85778308bf945e9b33ac604e6793df9b07933108d20bdf53811bc7c2798a4af"},
+    {file = "pydantic_core-2.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:3ded19dcaefe2f6706d81e0db787b59095f4ad0fbadce1edffdf092294c8a23f"},
+    {file = "pydantic_core-2.4.0.tar.gz", hash = "sha256:ec3473c9789cc00c7260d840c3db2c16dbfc816ca70ec87a00cddfa3e1a1cdd5"},
 ]
 
 [package.dependencies]
@@ -703,13 +720,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.3"
+version = "2.0.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
-    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
+    {file = "urllib3-2.0.4-py3-none-any.whl", hash = "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"},
+    {file = "urllib3-2.0.4.tar.gz", hash = "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"},
 ]
 
 [package.extras]

--- a/tests/responses/issue.json
+++ b/tests/responses/issue.json
@@ -91,7 +91,7 @@
       "$type": "SingleEnumIssueCustomField"
     },
     {
-      "value": 1645110000000,
+      "value": 1688472000000,
       "projectCustomField": {
         "field": {
           "fieldType": {

--- a/tests/responses/issues.json
+++ b/tests/responses/issues.json
@@ -92,7 +92,7 @@
         "$type": "SingleEnumIssueCustomField"
       },
       {
-        "value": 1645110000000,
+        "value": 1688472000000,
         "projectCustomField": {
           "field": {
             "fieldType": {

--- a/tests/responses/sprints.json
+++ b/tests/responses/sprints.json
@@ -114,7 +114,7 @@
             "$type": "SingleEnumIssueCustomField"
           },
           {
-            "value": 1645110000000,
+            "value": 1688472000000,
             "projectCustomField": {
               "field": {
                 "fieldType": {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -96,14 +96,14 @@ class TestClient(TestCase):
     def test_get_issue_comments(self):
         self.assertEqual(
             (
-                IssueComment.construct(
+                IssueComment.model_construct(
                     type="IssueComment",
                     id="4-296",
                     text="*Hello*, world!",
                     text_preview="<strong>Hello</strong>, world!",
                     created=datetime(2021, 12, 14, 11, 17, 48, tzinfo=UTC),
                     updated=None,
-                    author=User.construct(
+                    author=User.model_construct(
                         type="User",
                         id="1-3",
                         ring_id="b0fea1e1-ed18-43f6-a99d-40044fb1dfb0",
@@ -113,14 +113,14 @@ class TestClient(TestCase):
                     attachments=[],
                     deleted=False,
                 ),
-                IssueComment.construct(
+                IssueComment.model_construct(
                     type="IssueComment",
                     id="4-443",
                     text="Sample _comment_",
                     text_preview="Sample <em>comment</em>",
                     created=datetime(2021, 12, 15, 12, 51, 40, tzinfo=UTC),
                     updated=datetime(2021, 12, 15, 13, 8, 20, tzinfo=UTC),
-                    author=User.construct(
+                    author=User.model_construct(
                         type="User",
                         id="1-17",
                         ring_id="c5d08431-dd52-4cdd-9911-7ec3a18ad117",
@@ -130,14 +130,14 @@ class TestClient(TestCase):
                     attachments=[],
                     deleted=True,
                 ),
-                IssueComment.construct(
+                IssueComment.model_construct(
                     type="IssueComment",
                     id="4-678",
                     text="Comment with attachments",
                     text_preview="One attachment",
                     created=datetime(2021, 12, 21, 16, 41, 33, tzinfo=UTC),
                     updated=None,
-                    author=User.construct(
+                    author=User.model_construct(
                         type="User",
                         id="1-9",
                         ring_id="f19c93e1-833b-407b-a4de-7f9a3370aaf3",
@@ -145,7 +145,7 @@ class TestClient(TestCase):
                         email="sam@example.com",
                     ),
                     attachments=[
-                        IssueAttachment.construct(
+                        IssueAttachment.model_construct(
                             id="8-312",
                             type="IssueAttachment",
                             created=datetime(2021, 12, 21, 16, 41, 33, tzinfo=UTC),
@@ -166,13 +166,13 @@ class TestClient(TestCase):
     def test_get_projects(self):
         self.assertEqual(
             (
-                Project.construct(
+                Project.model_construct(
                     type="Project",
                     id="0-0",
                     name="Demo project",
                     short_name="DEMO",
                 ),
-                Project.construct(
+                Project.model_construct(
                     type="Project",
                     id="0-5",
                     name="Help Desk",
@@ -186,17 +186,17 @@ class TestClient(TestCase):
     def test_get_tags(self):
         self.assertEqual(
             (
-                Tag.construct(
+                Tag.model_construct(
                     type="Tag",
                     id="6-0",
                     name="productivity",
                 ),
-                Tag.construct(
+                Tag.model_construct(
                     type="Tag",
                     id="6-1",
                     name="tip",
                 ),
-                Tag.construct(
+                Tag.model_construct(
                     type="Tag",
                     id="6-5",
                     name="Star",
@@ -209,28 +209,28 @@ class TestClient(TestCase):
     def test_get_users(self):
         self.assertEqual(
             (
-                User.construct(
+                User.model_construct(
                     type="User",
                     id="1-17",
                     ring_id="c5d08431-dd52-4cdd-9911-7ec3a18ad117",
                     login="max.demo",
                     email="max@example.com",
                 ),
-                User.construct(
+                User.model_construct(
                     type="User",
                     id="1-3",
                     ring_id="b0fea1e1-ed18-43f6-a99d-40044fb1dfb0",
                     login="support",
                     email="support@example.com",
                 ),
-                User.construct(
+                User.model_construct(
                     type="User",
                     id="1-9",
                     ring_id="f19c93e1-833b-407b-a4de-7f9a3370aaf3",
                     login="sam",
                     email="sam@example.com",
                 ),
-                User.construct(
+                User.model_construct(
                     type="User",
                     id="1-10",
                     ring_id="20e4e701-7e87-45f8-8492-c448600b7991",
@@ -246,7 +246,7 @@ class TestClient(TestCase):
     def test_get_issue_link_types(self):
         self.assertEqual(
             (
-                IssueLinkType.construct(
+                IssueLinkType.model_construct(
                     type="IssueLinkType",
                     id="106-0",
                     name="Relates",
@@ -259,7 +259,7 @@ class TestClient(TestCase):
                     aggregation=False,
                     read_only=False,
                 ),
-                IssueLinkType.construct(
+                IssueLinkType.model_construct(
                     type="IssueLinkType",
                     id="106-1",
                     name="Depend",
@@ -272,7 +272,7 @@ class TestClient(TestCase):
                     aggregation=False,
                     read_only=False,
                 ),
-                IssueLinkType.construct(
+                IssueLinkType.model_construct(
                     type="IssueLinkType",
                     id="106-2",
                     name="Duplicate",
@@ -285,7 +285,7 @@ class TestClient(TestCase):
                     aggregation=True,
                     read_only=True,
                 ),
-                IssueLinkType.construct(
+                IssueLinkType.model_construct(
                     type="IssueLinkType",
                     id="106-3",
                     name="Subtask",
@@ -306,10 +306,10 @@ class TestClient(TestCase):
     def test_get_issue_links(self):
         self.assertEqual(
             (
-                IssueLink.construct(
+                IssueLink.model_construct(
                     id="106-0",
                     direction="BOTH",
-                    link_type=IssueLinkType.construct(
+                    link_type=IssueLinkType.model_construct(
                         type="IssueLinkType",
                         id="106-0",
                         name="Relates",
@@ -325,10 +325,10 @@ class TestClient(TestCase):
                     issues=[],
                     trimmed_issues=[],
                 ),
-                IssueLink.construct(
+                IssueLink.model_construct(
                     id="106-1s",
                     direction="OUTWARD",
-                    link_type=IssueLinkType.construct(
+                    link_type=IssueLinkType.model_construct(
                         type="IssueLinkType",
                         id="106-1",
                         name="Depend",
@@ -344,10 +344,10 @@ class TestClient(TestCase):
                     issues=[],
                     trimmed_issues=[],
                 ),
-                IssueLink.construct(
+                IssueLink.model_construct(
                     id="106-1t",
                     direction="INWARD",
-                    link_type=IssueLinkType.construct(
+                    link_type=IssueLinkType.model_construct(
                         type="IssueLinkType",
                         id="106-1",
                         name="Depend",
@@ -363,10 +363,10 @@ class TestClient(TestCase):
                     issues=[],
                     trimmed_issues=[],
                 ),
-                IssueLink.construct(
+                IssueLink.model_construct(
                     id="106-2s",
                     direction="OUTWARD",
-                    link_type=IssueLinkType.construct(
+                    link_type=IssueLinkType.model_construct(
                         type="IssueLinkType",
                         id="106-2",
                         name="Duplicate",
@@ -380,20 +380,20 @@ class TestClient(TestCase):
                         read_only=True,
                     ),
                     issues=[
-                        Issue.construct(
+                        Issue.model_construct(
                             type="Issue",
                             id="2-46619",
                             id_readable="PT-1839",
                             created=datetime(2022, 9, 26, 13, 50, 12, 810000, tzinfo=UTC),
                             updated=datetime(2022, 10, 5, 6, 28, 57, 291000, tzinfo=UTC),
                             resolved=datetime(2022, 9, 26, 13, 51, 29, 671000, tzinfo=UTC),
-                            project=Project.construct(
+                            project=Project.model_construct(
                                 type="Project",
                                 id="0-4",
                                 name="Test: project",
                                 short_name="PT",
                             ),
-                            reporter=User.construct(
+                            reporter=User.model_construct(
                                 type="User",
                                 id="1-52",
                                 name="Mary Jane",
@@ -401,7 +401,7 @@ class TestClient(TestCase):
                                 login="mary.jane",
                                 email=None,
                             ),
-                            updater=User.construct(
+                            updater=User.model_construct(
                                 type="User",
                                 id="1-64",
                                 name="Paul Lawson",
@@ -418,20 +418,20 @@ class TestClient(TestCase):
                         ),
                     ],
                     trimmed_issues=[
-                        Issue.construct(
+                        Issue.model_construct(
                             type="Issue",
                             id="2-46619",
                             id_readable="PT-1840",
                             created=datetime(2022, 9, 26, 13, 50, 12, 810000, tzinfo=UTC),
                             updated=datetime(2022, 10, 5, 6, 28, 57, 291000, tzinfo=UTC),
                             resolved=datetime(2022, 9, 26, 13, 51, 29, 671000, tzinfo=UTC),
-                            project=Project.construct(
+                            project=Project.model_construct(
                                 type="Project",
                                 id="0-4",
                                 name="Test: project",
                                 short_name="PT",
                             ),
-                            reporter=User.construct(
+                            reporter=User.model_construct(
                                 type="User",
                                 id="1-52",
                                 name="Mary Jane",
@@ -439,7 +439,7 @@ class TestClient(TestCase):
                                 login="mary.jane",
                                 email=None,
                             ),
-                            updater=User.construct(
+                            updater=User.model_construct(
                                 type="User",
                                 id="1-64",
                                 name="Paul Lawson",
@@ -456,10 +456,10 @@ class TestClient(TestCase):
                         ),
                     ],
                 ),
-                IssueLink.construct(
+                IssueLink.model_construct(
                     id="106-2t",
                     direction="INWARD",
-                    link_type=IssueLinkType.construct(
+                    link_type=IssueLinkType.model_construct(
                         type="IssueLinkType",
                         id="106-2",
                         name="Duplicate",
@@ -475,10 +475,10 @@ class TestClient(TestCase):
                     issues=[],
                     trimmed_issues=[],
                 ),
-                IssueLink.construct(
+                IssueLink.model_construct(
                     id="106-3s",
                     direction="OUTWARD",
-                    link_type=IssueLinkType.construct(
+                    link_type=IssueLinkType.model_construct(
                         type="IssueLinkType",
                         id="106-3",
                         name="Subtask",
@@ -494,10 +494,10 @@ class TestClient(TestCase):
                     issues=[],
                     trimmed_issues=[],
                 ),
-                IssueLink.construct(
+                IssueLink.model_construct(
                     id="106-3t",
                     direction="INWARD",
-                    link_type=IssueLinkType.construct(
+                    link_type=IssueLinkType.model_construct(
                         type="IssueLinkType",
                         id="106-3",
                         name="Subtask",
@@ -528,11 +528,11 @@ class TestClient(TestCase):
     def test_get_agiles(self):
         self.assertEqual(
             (
-                Agile.construct(
+                Agile.model_construct(
                     type="Agile",
                     id="120-0",
                     name="Demo Board",
-                    owner=User.construct(
+                    owner=User.model_construct(
                         type="User",
                         id="1-17",
                         name="Max Demo",
@@ -542,7 +542,7 @@ class TestClient(TestCase):
                     ),
                     visible_for=None,
                     projects=[
-                        Project.construct(
+                        Project.model_construct(
                             type="Project",
                             id="0-0",
                             name="Demo project",
@@ -550,13 +550,13 @@ class TestClient(TestCase):
                         ),
                     ],
                     sprints=[
-                        SprintRef.construct(
+                        SprintRef.model_construct(
                             type="Sprint",
                             id="121-12",
                             name="First sprint",
                         ),
                     ],
-                    current_sprint=SprintRef.construct(
+                    current_sprint=SprintRef.model_construct(
                         type="Sprint",
                         id="121-12",
                         name="First sprint",
@@ -579,7 +579,7 @@ class TestClient(TestCase):
         self.assertEqual(
             (
                 TEST_SPRINT,
-                Sprint.construct(
+                Sprint.model_construct(
                     type="Sprint",
                     id="121-11",
                     name="Week 2",
@@ -589,7 +589,7 @@ class TestClient(TestCase):
                     archived=False,
                     is_default=False,
                     unresolved_issues_count=0,
-                    agile=AgileRef.construct(
+                    agile=AgileRef.model_construct(
                         type="Agile",
                         id="120-8",
                         name="Kanban",

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -3,7 +3,7 @@ from datetime import UTC, date, datetime
 from typing import Literal, Optional, Sequence
 from unittest import TestCase
 
-from pydantic.v1 import Field
+from pydantic import Field
 
 from youtrack_sdk.entities import BaseModel
 from youtrack_sdk.helpers import custom_json_dumps, obj_to_dict
@@ -11,21 +11,21 @@ from youtrack_sdk.helpers import custom_json_dumps, obj_to_dict
 
 class SimpleModel(BaseModel):
     type: Literal["SimpleModel"] = Field(alias="$type", default="SimpleModel")
-    flag: Optional[bool]
-    short_name: Optional[str] = Field(alias="shortName")
-    value: Optional[int]
+    flag: Optional[bool] = None
+    short_name: Optional[str] = Field(alias="shortName", default=None)
+    value: Optional[int] = None
 
 
 class NestedModel(BaseModel):
     type: Literal["NestedModel"] = Field(alias="$type", default="NestedModel")
-    source: Optional[SimpleModel]
-    dest: Optional[SimpleModel]
+    source: Optional[SimpleModel] = None
+    dest: Optional[SimpleModel] = None
 
 
 class NestedSequenceModel(BaseModel):
     type: Literal["NestedSequenceModel"] = Field(alias="$type", default="NestedSequenceModel")
-    items: Optional[Sequence[NestedModel]]
-    stocks: Optional[Sequence[NestedModel]]
+    items: Optional[Sequence[NestedModel]] = None
+    stocks: Optional[Sequence[NestedModel]] = None
 
 
 class TestObjToDict(TestCase):
@@ -41,7 +41,7 @@ class TestObjToDict(TestCase):
                 "shortName": "Demo",
                 "value": None,
             },
-            obj_to_dict(SimpleModel.construct(short_name="Demo", value=None)),
+            obj_to_dict(SimpleModel.model_construct(short_name="Demo", value=None)),
         )
 
     def test_nested_model(self):
@@ -55,8 +55,8 @@ class TestObjToDict(TestCase):
                 },
             },
             obj_to_dict(
-                NestedModel.construct(
-                    source=SimpleModel.construct(short_name="Demo", value=None),
+                NestedModel.model_construct(
+                    source=SimpleModel.model_construct(short_name="Demo", value=None),
                 ),
             ),
         )
@@ -77,12 +77,12 @@ class TestObjToDict(TestCase):
                 ],
             },
             obj_to_dict(
-                NestedSequenceModel.construct(
+                NestedSequenceModel.model_construct(
                     items=[
-                        NestedModel.construct(),
-                        NestedModel.construct(
-                            source=SimpleModel.construct(short_name="Source", value=None),
-                            dest=SimpleModel.construct(short_name="Dest", value=5),
+                        NestedModel.model_construct(),
+                        NestedModel.model_construct(
+                            source=SimpleModel.model_construct(short_name="Source", value=None),
+                            dest=SimpleModel.model_construct(short_name="Dest", value=5),
                         ),
                     ],
                 ),

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,7 +1,7 @@
 from datetime import UTC, date, datetime
 from typing import Literal, Optional, Sequence
 
-from pydantic.v1 import Field
+from pydantic import Field
 
 from youtrack_sdk.entities import (
     Agile,
@@ -33,35 +33,35 @@ from youtrack_sdk.entities import (
 
 class CustomIssue(BaseModel):
     type: Literal["Issue"] = Field(alias="$type", default="Issue")
-    id_readable: Optional[str] = Field(alias="idReadable")
-    created: Optional[datetime]
-    updated: Optional[datetime]
-    resolved: Optional[datetime]
-    comments_count: Optional[int] = Field(alias="commentsCount")
-    custom_fields: Optional[Sequence[IssueCustomFieldType]] = Field(alias="customFields")
+    id_readable: Optional[str] = Field(alias="idReadable", default=None)
+    created: Optional[datetime] = None
+    updated: Optional[datetime] = None
+    resolved: Optional[datetime] = None
+    comments_count: Optional[int] = Field(alias="commentsCount", default=None)
+    custom_fields: Optional[Sequence[IssueCustomFieldType]] = Field(alias="customFields", default=None)
 
 
-TEST_ISSUE = Issue.construct(
+TEST_ISSUE = Issue.model_construct(
     type="Issue",
     id="1-937",
     id_readable="HD-25",
     created=datetime(2021, 2, 9, 14, 3, 11, tzinfo=UTC),
     updated=datetime(2021, 8, 22, 10, 28, 16, tzinfo=UTC),
     resolved=None,
-    project=Project.construct(
+    project=Project.model_construct(
         type="Project",
         id="0-1",
         name="Help Desk",
         short_name="HD",
     ),
-    reporter=User.construct(
+    reporter=User.model_construct(
         type="User",
         id="1-3",
         ring_id="b0fea1e1-ed18-43f6-a99d-40044fb1dfb0",
         login="support",
         email="support@example.com",
     ),
-    updater=User.construct(
+    updater=User.model_construct(
         type="User",
         id="1-17",
         ring_id="c5d08431-dd52-4cdd-9911-7ec3a18ad117",
@@ -72,21 +72,21 @@ TEST_ISSUE = Issue.construct(
     description="Issue description",
     wikified_description="Wikified issue description",
     comments_count=7,
-    tags=[Tag.construct(type="Tag", id="5-7", name="Review")],
+    tags=[Tag.model_construct(type="Tag", id="5-7", name="Review")],
     custom_fields=[
-        StateIssueCustomField.construct(
+        StateIssueCustomField.model_construct(
             id="110-50",
             name="State",
             type="StateIssueCustomField",
-            value=StateBundleElement.construct(
+            value=StateBundleElement.model_construct(
                 id="98-37",
                 name="In Progress",
                 type="StateBundleElement",
             ),
-            project_custom_field=StateProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=StateProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(
+                    field_type=FieldType.model_construct(
                         type="FieldType",
                         id="state[1]",
                     ),
@@ -94,11 +94,11 @@ TEST_ISSUE = Issue.construct(
                 type="StateProjectCustomField",
             ),
         ),
-        SingleUserIssueCustomField.construct(
+        SingleUserIssueCustomField.model_construct(
             id="111-8",
             name="Assignee",
             type="SingleUserIssueCustomField",
-            value=User.construct(
+            value=User.model_construct(
                 type="User",
                 id="1-10",
                 ring_id="20e4e701-7e87-45f8-8492-c448600b7991",
@@ -106,52 +106,52 @@ TEST_ISSUE = Issue.construct(
                 login="worker",
                 email="worker@example.com",
             ),
-            project_custom_field=UserProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=UserProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="user[1]"),
+                    field_type=FieldType.model_construct(type="FieldType", id="user[1]"),
                 ),
                 type="UserProjectCustomField",
             ),
         ),
-        SingleEnumIssueCustomField.construct(
+        SingleEnumIssueCustomField.model_construct(
             id="110-49",
             name="Type",
             type="SingleEnumIssueCustomField",
-            value=EnumBundleElement.construct(
+            value=EnumBundleElement.model_construct(
                 id="96-38",
                 name="Value One",
                 type="EnumBundleElement",
             ),
-            project_custom_field=EnumProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=EnumProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="enum[1]"),
+                    field_type=FieldType.model_construct(type="FieldType", id="enum[1]"),
                 ),
                 type="EnumProjectCustomField",
             ),
         ),
-        DateIssueCustomField.construct(
+        DateIssueCustomField.model_construct(
             id="145-34",
             name="Due Date",
             type="DateIssueCustomField",
-            value=date(2022, 2, 17),
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            value=date(2023, 7, 4),
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="date"),
+                    field_type=FieldType.model_construct(type="FieldType", id="date"),
                 ),
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-35",
             name="Started at",
             type="SimpleIssueCustomField",
             value=datetime(2021, 6, 11, 7, 32, 9, tzinfo=UTC),
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(
+                    field_type=FieldType.model_construct(
                         type="FieldType",
                         id="date and time",
                     ),
@@ -159,54 +159,54 @@ TEST_ISSUE = Issue.construct(
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-36",
             name="Multipass",
             type="SimpleIssueCustomField",
             value="1623396729",
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="string"),
+                    field_type=FieldType.model_construct(type="FieldType", id="string"),
                 ),
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-39",
             name="Price",
             type="SimpleIssueCustomField",
             value=4003,
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="integer"),
+                    field_type=FieldType.model_construct(type="FieldType", id="integer"),
                 ),
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-37",
             name="Multiplier",
             type="SimpleIssueCustomField",
             value=3.1412,
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="float"),
+                    field_type=FieldType.model_construct(type="FieldType", id="float"),
                 ),
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-38",
             name="Extra",
             type="SimpleIssueCustomField",
             value=None,
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="string"),
+                    field_type=FieldType.model_construct(type="FieldType", id="string"),
                 ),
                 type="SimpleProjectCustomField",
             ),
@@ -214,27 +214,27 @@ TEST_ISSUE = Issue.construct(
     ],
 )
 
-TEST_ISSUE_2 = Issue.construct(
+TEST_ISSUE_2 = Issue.model_construct(
     type="Issue",
     id="2-48",
     id_readable="HD-17",
     created=datetime(2022, 10, 26, 9, 44, 44, tzinfo=UTC),
     updated=datetime(2022, 10, 27, 16, 46, 11, tzinfo=UTC),
     resolved=datetime(2022, 10, 30, 18, 1, 55, tzinfo=UTC),
-    project=Project.construct(
+    project=Project.model_construct(
         type="Project",
         id="0-1",
         name="Help Desk",
         short_name="HD",
     ),
-    reporter=User.construct(
+    reporter=User.model_construct(
         type="User",
         id="1-1",
         ring_id="8711cd4-90e3-445d-87ae-0925c9e1159d",
         login="alex",
         email="alex@example.com",
     ),
-    updater=User.construct(
+    updater=User.model_construct(
         type="User",
         id="1-17",
         ring_id="c5d08431-dd52-4cdd-9911-7ec3a18ad117",
@@ -247,19 +247,19 @@ TEST_ISSUE_2 = Issue.construct(
     comments_count=0,
     tags=[],
     custom_fields=[
-        StateIssueCustomField.construct(
+        StateIssueCustomField.model_construct(
             id="110-50",
             name="State",
             type="StateIssueCustomField",
-            value=StateBundleElement.construct(
+            value=StateBundleElement.model_construct(
                 id="98-22",
                 name="Fixed",
                 type="StateBundleElement",
             ),
-            project_custom_field=StateProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=StateProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(
+                    field_type=FieldType.model_construct(
                         type="FieldType",
                         id="state[1]",
                     ),
@@ -267,57 +267,57 @@ TEST_ISSUE_2 = Issue.construct(
                 type="StateProjectCustomField",
             ),
         ),
-        SingleUserIssueCustomField.construct(
+        SingleUserIssueCustomField.model_construct(
             id="111-8",
             name="Assignee",
             type="SingleUserIssueCustomField",
             value=None,
-            project_custom_field=UserProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=UserProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="user[1]"),
+                    field_type=FieldType.model_construct(type="FieldType", id="user[1]"),
                 ),
                 type="UserProjectCustomField",
             ),
         ),
-        SingleEnumIssueCustomField.construct(
+        SingleEnumIssueCustomField.model_construct(
             id="110-49",
             name="Type",
             type="SingleEnumIssueCustomField",
-            value=EnumBundleElement.construct(
+            value=EnumBundleElement.model_construct(
                 id="96-95",
                 name="Other",
                 type="EnumBundleElement",
             ),
-            project_custom_field=EnumProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=EnumProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="enum[1]"),
+                    field_type=FieldType.model_construct(type="FieldType", id="enum[1]"),
                 ),
                 type="EnumProjectCustomField",
             ),
         ),
-        DateIssueCustomField.construct(
+        DateIssueCustomField.model_construct(
             id="145-34",
             name="Due Date",
             type="DateIssueCustomField",
             value=None,
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="date"),
+                    field_type=FieldType.model_construct(type="FieldType", id="date"),
                 ),
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-35",
             name="Started at",
             type="SimpleIssueCustomField",
             value=datetime(2022, 10, 26, 19, 21, 4, tzinfo=UTC),
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(
+                    field_type=FieldType.model_construct(
                         type="FieldType",
                         id="date and time",
                     ),
@@ -325,54 +325,54 @@ TEST_ISSUE_2 = Issue.construct(
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-36",
             name="Multipass",
             type="SimpleIssueCustomField",
             value="2000000000000",
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="string"),
+                    field_type=FieldType.model_construct(type="FieldType", id="string"),
                 ),
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-39",
             name="Price",
             type="SimpleIssueCustomField",
             value=-128,
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="integer"),
+                    field_type=FieldType.model_construct(type="FieldType", id="integer"),
                 ),
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-37",
             name="Multiplier",
             type="SimpleIssueCustomField",
             value=-2.4,
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="float"),
+                    field_type=FieldType.model_construct(type="FieldType", id="float"),
                 ),
                 type="SimpleProjectCustomField",
             ),
         ),
-        SimpleIssueCustomField.construct(
+        SimpleIssueCustomField.model_construct(
             id="145-38",
             name="Extra",
             type="SimpleIssueCustomField",
             value=None,
-            project_custom_field=SimpleProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=SimpleProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="string"),
+                    field_type=FieldType.model_construct(type="FieldType", id="string"),
                 ),
                 type="SimpleProjectCustomField",
             ),
@@ -380,7 +380,7 @@ TEST_ISSUE_2 = Issue.construct(
     ],
 )
 
-TEST_CUSTOM_ISSUE = CustomIssue.construct(
+TEST_CUSTOM_ISSUE = CustomIssue.model_construct(
     type="Issue",
     id_readable="HD-25",
     created=datetime(2021, 2, 9, 14, 3, 11, tzinfo=UTC),
@@ -388,19 +388,19 @@ TEST_CUSTOM_ISSUE = CustomIssue.construct(
     resolved=None,
     comments_count=7,
     custom_fields=[
-        StateIssueCustomField.construct(
+        StateIssueCustomField.model_construct(
             id="110-50",
             name="State",
             type="StateIssueCustomField",
-            value=StateBundleElement.construct(
+            value=StateBundleElement.model_construct(
                 id="98-37",
                 name="In Progress",
                 type="StateBundleElement",
             ),
-            project_custom_field=StateProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=StateProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(
+                    field_type=FieldType.model_construct(
                         type="FieldType",
                         id="state[1]",
                     ),
@@ -408,19 +408,19 @@ TEST_CUSTOM_ISSUE = CustomIssue.construct(
                 type="StateProjectCustomField",
             ),
         ),
-        SingleEnumIssueCustomField.construct(
+        SingleEnumIssueCustomField.model_construct(
             id="110-49",
             name="Type",
             type="SingleEnumIssueCustomField",
-            value=EnumBundleElement.construct(
+            value=EnumBundleElement.model_construct(
                 id="96-38",
                 name="Value One",
                 type="EnumBundleElement",
             ),
-            project_custom_field=EnumProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=EnumProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="enum[1]"),
+                    field_type=FieldType.model_construct(type="FieldType", id="enum[1]"),
                 ),
                 type="EnumProjectCustomField",
             ),
@@ -428,7 +428,7 @@ TEST_CUSTOM_ISSUE = CustomIssue.construct(
     ],
 )
 
-TEST_CUSTOM_ISSUE_2 = CustomIssue.construct(
+TEST_CUSTOM_ISSUE_2 = CustomIssue.model_construct(
     type="Issue",
     id_readable="HD-17",
     created=datetime(2022, 10, 26, 9, 44, 44, tzinfo=UTC),
@@ -436,19 +436,19 @@ TEST_CUSTOM_ISSUE_2 = CustomIssue.construct(
     resolved=datetime(2022, 10, 30, 18, 1, 55, tzinfo=UTC),
     comments_count=0,
     custom_fields=[
-        StateIssueCustomField.construct(
+        StateIssueCustomField.model_construct(
             id="110-50",
             name="State",
             type="StateIssueCustomField",
-            value=StateBundleElement.construct(
+            value=StateBundleElement.model_construct(
                 id="98-22",
                 name="Fixed",
                 type="StateBundleElement",
             ),
-            project_custom_field=StateProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=StateProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(
+                    field_type=FieldType.model_construct(
                         type="FieldType",
                         id="state[1]",
                     ),
@@ -456,19 +456,19 @@ TEST_CUSTOM_ISSUE_2 = CustomIssue.construct(
                 type="StateProjectCustomField",
             ),
         ),
-        SingleEnumIssueCustomField.construct(
+        SingleEnumIssueCustomField.model_construct(
             id="110-49",
             name="Type",
             type="SingleEnumIssueCustomField",
-            value=EnumBundleElement.construct(
+            value=EnumBundleElement.model_construct(
                 id="96-95",
                 name="Other",
                 type="EnumBundleElement",
             ),
-            project_custom_field=EnumProjectCustomField.construct(
-                field=CustomField.construct(
+            project_custom_field=EnumProjectCustomField.model_construct(
+                field=CustomField.model_construct(
                     type="CustomField",
-                    field_type=FieldType.construct(type="FieldType", id="enum[1]"),
+                    field_type=FieldType.model_construct(type="FieldType", id="enum[1]"),
                 ),
                 type="EnumProjectCustomField",
             ),
@@ -476,11 +476,11 @@ TEST_CUSTOM_ISSUE_2 = CustomIssue.construct(
     ],
 )
 
-TEST_AGILE = Agile.construct(
+TEST_AGILE = Agile.model_construct(
     type="Agile",
     id="120-8",
     name="Kanban",
-    owner=User.construct(
+    owner=User.model_construct(
         type="User",
         id="1-17",
         name="Max Demo",
@@ -488,14 +488,14 @@ TEST_AGILE = Agile.construct(
         login="max.demo",
         email="max@example.com",
     ),
-    visible_for=UserGroup.construct(
+    visible_for=UserGroup.model_construct(
         type="UserGroup",
         id="3-20",
         name="Registered Users",
         ring_id="38012ba2-2b67-4ca3-a72b-523408d85b6d",
     ),
     projects=[
-        Project.construct(
+        Project.model_construct(
             type="Project",
             id="0-13",
             name="Kanban",
@@ -503,25 +503,25 @@ TEST_AGILE = Agile.construct(
         ),
     ],
     sprints=[
-        SprintRef.construct(
+        SprintRef.model_construct(
             type="Sprint",
             id="121-8",
             name="Week 1",
         ),
-        SprintRef.construct(
+        SprintRef.model_construct(
             type="Sprint",
             id="121-11",
             name="Week 2",
         ),
     ],
-    current_sprint=SprintRef.construct(
+    current_sprint=SprintRef.model_construct(
         type="Sprint",
         id="121-11",
         name="Week 2",
     ),
 )
 
-TEST_SPRINT = Sprint.construct(
+TEST_SPRINT = Sprint.model_construct(
     type="Sprint",
     id="121-8",
     name="Week 1",
@@ -531,7 +531,7 @@ TEST_SPRINT = Sprint.construct(
     archived=False,
     is_default=False,
     unresolved_issues_count=0,
-    agile=AgileRef.construct(
+    agile=AgileRef.model_construct(
         type="Agile",
         id="120-8",
         name="Kanban",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,7 @@
 from typing import Literal, Optional, Sequence, Union
 from unittest import TestCase
 
-from pydantic.v1 import Field
+from pydantic import Field
 
 from youtrack_sdk.entities import BaseModel
 from youtrack_sdk.helpers import model_to_field_names
@@ -9,19 +9,19 @@ from youtrack_sdk.helpers import model_to_field_names
 
 class SimpleModel(BaseModel):
     type: Literal["SimpleModel"] = Field(alias="$type", default="SimpleModel")
-    id: Optional[int]
-    short_name: Optional[str] = Field(alias="shortName")
+    id: Optional[int] = None
+    short_name: Optional[str] = Field(alias="shortName", default=None)
 
 
 class NestedModel(BaseModel):
     type: Literal["NestedModel"] = Field(alias="$type", default="NestedModel")
-    value: Optional[SimpleModel]
+    value: Optional[SimpleModel] = None
 
 
 class NestedUnionModel(BaseModel):
     type: Literal["NestedUnionModel"] = Field(alias="$type", default="NestedUnionModel")
-    items: Optional[Sequence[NestedModel | SimpleModel | int]]
-    entry: Optional[NestedModel | SimpleModel | int]
+    items: Optional[Sequence[NestedModel | SimpleModel | int]] = None
+    entry: Optional[NestedModel | SimpleModel | int] = None
 
 
 class TestModelToFieldNames(TestCase):

--- a/youtrack_sdk/client.py
+++ b/youtrack_sdk/client.py
@@ -3,7 +3,7 @@ from json import JSONDecodeError
 from typing import IO, Optional, Sequence, Type, TypeVar
 from urllib.parse import urlencode
 
-from pydantic.v1 import parse_obj_as
+from pydantic import TypeAdapter
 from requests import HTTPError, Session
 
 from .entities import (
@@ -134,7 +134,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/operations-api-issues.html#get-Issue-method
         """
-        return Issue.parse_obj(
+        return Issue.model_validate(
             self._get(
                 url=self._build_url(
                     path=f"/issues/{issue_id}",
@@ -157,8 +157,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues.html#get_all-Issue-method
         """
-        return parse_obj_as(
-            tuple[model, ...],
+        return TypeAdapter(tuple[model, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path="/issues/",
@@ -176,7 +175,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues.html#create-Issue-method
         """
-        return Issue.parse_obj(
+        return Issue.model_validate(
             self._post(
                 url=self._build_url(
                     path="/issues",
@@ -191,7 +190,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/operations-api-issues.html#update-Issue-method
         """
-        return Issue.parse_obj(
+        return Issue.model_validate(
             self._post(
                 url=self._build_url(
                     path=f"/issues/{issue_id}",
@@ -213,8 +212,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-customFields.html#get_all-IssueCustomField-method
         """
-        return parse_obj_as(
-            tuple[IssueCustomFieldType, ...],
+        return TypeAdapter(tuple[IssueCustomFieldType, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/customFields",
@@ -230,8 +228,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/operations-api-issues-issueID-customFields.html#update-IssueCustomField-method
         """
-        return parse_obj_as(
-            IssueCustomFieldType,
+        return TypeAdapter(IssueCustomFieldType).validate_python(
             self._post(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/customFields/{field.id}",
@@ -257,8 +254,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-comments.html#get_all-IssueComment-method
         """
-        return parse_obj_as(
-            tuple[IssueComment, ...],
+        return TypeAdapter(tuple[IssueComment, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/comments",
@@ -274,7 +270,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-comments.html#create-IssueComment-method
         """
-        return IssueComment.parse_obj(
+        return IssueComment.model_validate(
             self._post(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/comments",
@@ -289,7 +285,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/operations-api-issues-issueID-comments.html#update-IssueComment-method
         """
-        return IssueComment.parse_obj(
+        return IssueComment.model_validate(
             self._post(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/comments/{comment.id}",
@@ -322,8 +318,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-attachments.html#get_all-IssueAttachment-method
         """
-        return parse_obj_as(
-            tuple[IssueAttachment, ...],
+        return TypeAdapter(tuple[IssueAttachment, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/attachments",
@@ -340,8 +335,7 @@ class Client:
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-attachments.html#create-IssueAttachment-method
         https://www.jetbrains.com/help/youtrack/devportal/api-usecase-attach-files.html
         """
-        return parse_obj_as(
-            tuple[IssueAttachment, ...],
+        return TypeAdapter(tuple[IssueAttachment, ...]).validate_python(
             self._post(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/attachments",
@@ -358,8 +352,7 @@ class Client:
         comment_id: str,
         files: dict[str, IO],
     ) -> Sequence[IssueAttachment]:
-        return parse_obj_as(
-            tuple[IssueAttachment, ...],
+        return TypeAdapter(tuple[IssueAttachment, ...]).validate_python(
             self._post(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/comments/{comment_id}/attachments",
@@ -374,8 +367,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-admin-projects.html#get_all-Project-method
         """
-        return parse_obj_as(
-            tuple[Project, ...],
+        return TypeAdapter(tuple[Project, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path="/admin/projects",
@@ -391,8 +383,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-tags.html#get_all-Tag-method
         """
-        return parse_obj_as(
-            tuple[Tag, ...],
+        return TypeAdapter(tuple[Tag, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path="/tags",
@@ -420,8 +411,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-users.html#get_all-User-method
         """
-        return parse_obj_as(
-            tuple[User, ...],
+        return TypeAdapter(tuple[User, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path="/users",
@@ -437,8 +427,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-links.html#get_all-IssueLink-method
         """
-        return parse_obj_as(
-            tuple[IssueLink, ...],
+        return TypeAdapter(tuple[IssueLink, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path=f"/issues/{issue_id}/links",
@@ -454,8 +443,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issueLinkTypes.html#get_all-IssueLinkType-method
         """
-        return parse_obj_as(
-            tuple[IssueLinkType, ...],
+        return TypeAdapter(tuple[IssueLinkType, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path="/issueLinkTypes",
@@ -478,8 +466,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-issues-issueID-links-linkID-issues.html#create-Issue-method
         """
-        return parse_obj_as(
-            Issue,
+        return TypeAdapter(Issue).validate_python(
             self._post(
                 url=self._build_url(
                     path=f"/issues/{source_issue_id}/links/{link_type_id}{link_direction.value}/issues",
@@ -511,8 +498,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-agiles.html#get_all-Agile-method
         """
-        return parse_obj_as(
-            tuple[Agile, ...],
+        return TypeAdapter(tuple[Agile, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path="/agiles",
@@ -528,7 +514,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/operations-api-agiles.html#get-Agile-method
         """
-        return Agile.parse_obj(
+        return Agile.model_validate(
             self._get(
                 url=self._build_url(
                     path=f"/agiles/{agile_id}",
@@ -542,8 +528,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/resource-api-agiles-agileID-sprints.html#get_all-Sprint-method
         """
-        return parse_obj_as(
-            tuple[Sprint, ...],
+        return TypeAdapter(tuple[Sprint, ...]).validate_python(
             self._get(
                 url=self._build_url(
                     path=f"/agiles/{agile_id}/sprints",
@@ -559,7 +544,7 @@ class Client:
 
         https://www.jetbrains.com/help/youtrack/devportal/operations-api-agiles-agileID-sprints.html#get-Sprint-method
         """
-        return Sprint.parse_obj(
+        return Sprint.model_validate(
             self._get(
                 url=self._build_url(
                     path=f"/agiles/{agile_id}/sprints/{sprint_id}",

--- a/youtrack_sdk/entities.py
+++ b/youtrack_sdk/entities.py
@@ -1,44 +1,45 @@
-from datetime import date, datetime
 from typing import Literal, Optional, Sequence
 
-from pydantic.v1 import BaseModel as PydanticBaseModel
-from pydantic.v1 import Field, StrictFloat, StrictInt, StrictStr
+from pydantic import AwareDatetime
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict, Field, StrictFloat, StrictInt, StrictStr, field_validator
 
-from .types import DateTime
+from .types import YouTrackDate, validate_youtrack_datetime
 
 
 class BaseModel(PydanticBaseModel):
-    class Config:
-        allow_population_by_field_name = True  # allow to use field name or alias to populate a model
-        frozen = True  # make instance immutable and hashable
+    model_config = ConfigDict(
+        populate_by_name=True,  # allow to use field name or alias to populate a model
+        frozen=True,  # make instance immutable and hashable
+    )
 
 
 class User(BaseModel):
     type: Literal["User", "Me"] = Field(alias="$type", default="User")
-    id: Optional[str]
-    name: Optional[str]
-    ring_id: Optional[str] = Field(alias="ringId")
-    login: Optional[str]
-    email: Optional[str]
+    id: Optional[str] = None
+    name: Optional[str] = None
+    ring_id: Optional[str] = Field(alias="ringId", default=None)
+    login: Optional[str] = None
+    email: Optional[str] = None
 
 
 class TextFieldValue(BaseModel):
     type: Literal["TextFieldValue"] = Field(alias="$type", default="TextFieldValue")
-    id: Optional[str]
-    text: Optional[str]
-    markdownText: Optional[str]
+    id: Optional[str] = None
+    text: Optional[str] = None
+    markdownText: Optional[str] = None
 
 
 class PeriodValue(BaseModel):
     type: Literal["PeriodValue"] = Field(alias="$type", default="PeriodValue")
-    id: Optional[str]
-    minutes: Optional[int]
-    presentation: Optional[str]
+    id: Optional[str] = None
+    minutes: Optional[int] = None
+    presentation: Optional[str] = None
 
 
 class BundleElement(BaseModel):
-    id: Optional[str]
-    name: Optional[str]
+    id: Optional[str] = None
+    name: Optional[str] = None
 
 
 class BuildBundleElement(BundleElement):
@@ -63,23 +64,23 @@ class StateBundleElement(BundleElement):
 
 class UserGroup(BaseModel):
     type: Literal["UserGroup"] = Field(alias="$type", default="UserGroup")
-    id: Optional[str]
-    name: Optional[str]
-    ring_id: Optional[str] = Field(alias="ringId")
+    id: Optional[str] = None
+    name: Optional[str] = None
+    ring_id: Optional[str] = Field(alias="ringId", default=None)
 
 
 class FieldType(BaseModel):
     type: Literal["FieldType"] = Field(alias="$type", default="FieldType")
-    id: Optional[str]
+    id: Optional[str] = None
 
 
 class CustomField(BaseModel):
     type: Literal["CustomField"] = Field(alias="$type", default="CustomField")
-    field_type: Optional[FieldType] = Field(alias="fieldType")
+    field_type: Optional[FieldType] = Field(alias="fieldType", default=None)
 
 
 class ProjectCustomField(BaseModel):
-    field: Optional[CustomField]
+    field: Optional[CustomField] = None
 
 
 class GroupProjectCustomField(ProjectCustomField):
@@ -142,29 +143,30 @@ ProjectCustomFieldType = (
 
 
 class IssueCustomField(BaseModel):
-    id: Optional[str]
-    name: Optional[str]
-    project_custom_field: Optional[ProjectCustomFieldType] = Field(alias="projectCustomField")
+    id: Optional[str] = None
+    name: Optional[str] = None
+    project_custom_field: Optional[ProjectCustomFieldType] = Field(alias="projectCustomField", default=None)
 
 
 class TextIssueCustomField(IssueCustomField):
     type: Literal["TextIssueCustomField"] = Field(alias="$type", default="TextIssueCustomField")
-    value: Optional[TextFieldValue]
+    value: Optional[TextFieldValue] = None
 
 
 class SimpleIssueCustomField(IssueCustomField):
     type: Literal["SimpleIssueCustomField"] = Field(alias="$type", default="SimpleIssueCustomField")
-    value: Optional[DateTime | StrictStr | StrictInt | StrictFloat]
+    value: Optional[AwareDatetime | StrictStr | StrictInt | StrictFloat] = None
+    validate_value = field_validator("value")(validate_youtrack_datetime)
 
 
 class DateIssueCustomField(SimpleIssueCustomField):
     type: Literal["DateIssueCustomField"] = Field(alias="$type", default="DateIssueCustomField")
-    value: Optional[date]
+    value: Optional[YouTrackDate] = None
 
 
 class PeriodIssueCustomField(IssueCustomField):
     type: Literal["PeriodIssueCustomField"] = Field(alias="$type", default="PeriodIssueCustomField")
-    value: Optional[PeriodValue]
+    value: Optional[PeriodValue] = None
 
 
 class MultiBuildIssueCustomField(IssueCustomField):
@@ -199,37 +201,37 @@ class MultiVersionIssueCustomField(IssueCustomField):
 
 class SingleBuildIssueCustomField(IssueCustomField):
     type: Literal["SingleBuildIssueCustomField"] = Field(alias="$type", default="SingleBuildIssueCustomField")
-    value: Optional[BuildBundleElement]
+    value: Optional[BuildBundleElement] = None
 
 
 class SingleEnumIssueCustomField(IssueCustomField):
     type: Literal["SingleEnumIssueCustomField"] = Field(alias="$type", default="SingleEnumIssueCustomField")
-    value: Optional[EnumBundleElement]
+    value: Optional[EnumBundleElement] = None
 
 
 class SingleGroupIssueCustomField(IssueCustomField):
     type: Literal["SingleGroupIssueCustomField"] = Field(alias="$type", default="SingleGroupIssueCustomField")
-    value: Optional[UserGroup]
+    value: Optional[UserGroup] = None
 
 
 class SingleOwnedIssueCustomField(IssueCustomField):
     type: Literal["SingleOwnedIssueCustomField"] = Field(alias="$type", default="SingleOwnedIssueCustomField")
-    value: Optional[OwnedBundleElement]
+    value: Optional[OwnedBundleElement] = None
 
 
 class SingleUserIssueCustomField(IssueCustomField):
     type: Literal["SingleUserIssueCustomField"] = Field(alias="$type", default="SingleUserIssueCustomField")
-    value: Optional[User]
+    value: Optional[User] = None
 
 
 class SingleVersionIssueCustomField(IssueCustomField):
     type: Literal["SingleVersionIssueCustomField"] = Field(alias="$type", default="SingleVersionIssueCustomField")
-    value: Optional[VersionBundleElement]
+    value: Optional[VersionBundleElement] = None
 
 
 class StateIssueCustomField(IssueCustomField):
     type: Literal["StateIssueCustomField"] = Field(alias="$type", default="StateIssueCustomField")
-    value: Optional[StateBundleElement]
+    value: Optional[StateBundleElement] = None
 
 
 IssueCustomFieldType = (
@@ -255,107 +257,107 @@ IssueCustomFieldType = (
 
 class Project(BaseModel):
     type: Literal["Project"] = Field(alias="$type", default="Project")
-    id: Optional[str]
-    name: Optional[str]
-    short_name: Optional[str] = Field(alias="shortName")
+    id: Optional[str] = None
+    name: Optional[str] = None
+    short_name: Optional[str] = Field(alias="shortName", default=None)
 
 
 class Tag(BaseModel):
     type: Literal["Tag"] = Field(alias="$type", default="Tag")
-    id: Optional[str]
-    name: Optional[str]
+    id: Optional[str] = None
+    name: Optional[str] = None
 
 
 class Issue(BaseModel):
     type: Literal["Issue"] = Field(alias="$type", default="Issue")
-    id: Optional[str]
-    id_readable: Optional[str] = Field(alias="idReadable")
-    created: Optional[datetime]
-    updated: Optional[datetime]
-    resolved: Optional[datetime]
-    project: Optional[Project]
-    reporter: Optional[User]
-    updater: Optional[User]
-    summary: Optional[str]
-    description: Optional[str]
-    wikified_description: Optional[str] = Field(alias="wikifiedDescription")
-    comments_count: Optional[int] = Field(alias="commentsCount")
-    tags: Optional[Sequence[Tag]]
-    custom_fields: Optional[Sequence[IssueCustomFieldType]] = Field(alias="customFields")
+    id: Optional[str] = None
+    id_readable: Optional[str] = Field(alias="idReadable", default=None)
+    created: Optional[AwareDatetime] = None
+    updated: Optional[AwareDatetime] = None
+    resolved: Optional[AwareDatetime] = None
+    project: Optional[Project] = None
+    reporter: Optional[User] = None
+    updater: Optional[User] = None
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    wikified_description: Optional[str] = Field(alias="wikifiedDescription", default=None)
+    comments_count: Optional[int] = Field(alias="commentsCount", default=None)
+    tags: Optional[Sequence[Tag]] = None
+    custom_fields: Optional[Sequence[IssueCustomFieldType]] = Field(alias="customFields", default=None)
 
 
 class IssueAttachment(BaseModel):
     type: Literal["IssueAttachment"] = Field(alias="$type", default="IssueAttachment")
-    id: Optional[str]
-    name: Optional[str]
-    author: Optional[User]
-    created: Optional[datetime]
-    updated: Optional[datetime]
-    mime_type: Optional[str] = Field(alias="mimeType")
-    url: Optional[str]
+    id: Optional[str] = None
+    name: Optional[str] = None
+    author: Optional[User] = None
+    created: Optional[AwareDatetime] = None
+    updated: Optional[AwareDatetime] = None
+    mime_type: Optional[str] = Field(alias="mimeType", default=None)
+    url: Optional[str] = None
 
 
 class IssueComment(BaseModel):
     type: Literal["IssueComment"] = Field(alias="$type", default="IssueComment")
-    id: Optional[str]
-    text: Optional[str]
-    text_preview: Optional[str] = Field(alias="textPreview")
-    created: Optional[datetime]
-    updated: Optional[datetime]
-    author: Optional[User]
-    attachments: Optional[Sequence[IssueAttachment]]
-    deleted: Optional[bool]
+    id: Optional[str] = None
+    text: Optional[str] = None
+    text_preview: Optional[str] = Field(alias="textPreview", default=None)
+    created: Optional[AwareDatetime] = None
+    updated: Optional[AwareDatetime] = None
+    author: Optional[User] = None
+    attachments: Optional[Sequence[IssueAttachment]] = None
+    deleted: Optional[bool] = None
 
 
 class IssueLinkType(BaseModel):
     type: Literal["IssueLinkType"] = Field(alias="$type", default="IssueLinkType")
-    id: Optional[str]
-    name: Optional[str]
-    localized_name: Optional[str] = Field(alias="localizedName")
-    source_to_target: Optional[str] = Field(alias="sourceToTarget")
-    localized_source_to_target: Optional[str] = Field(alias="localizedSourceToTarget")
-    target_to_source: Optional[str] = Field(alias="targetToSource")
-    localized_target_to_source: Optional[str] = Field(alias="localizedTargetToSource")
-    directed: Optional[bool]
-    aggregation: Optional[bool]
-    read_only: Optional[bool] = Field(alias="readOnly")
+    id: Optional[str] = None
+    name: Optional[str] = None
+    localized_name: Optional[str] = Field(alias="localizedName", default=None)
+    source_to_target: Optional[str] = Field(alias="sourceToTarget", default=None)
+    localized_source_to_target: Optional[str] = Field(alias="localizedSourceToTarget", default=None)
+    target_to_source: Optional[str] = Field(alias="targetToSource", default=None)
+    localized_target_to_source: Optional[str] = Field(alias="localizedTargetToSource", default=None)
+    directed: Optional[bool] = None
+    aggregation: Optional[bool] = None
+    read_only: Optional[bool] = Field(alias="readOnly", default=None)
 
 
 class IssueLink(BaseModel):
-    id: Optional[str]
-    direction: Optional[Literal["OUTWARD", "INWARD", "BOTH"]]
-    link_type: Optional[IssueLinkType] = Field(alias="linkType")
-    issues: Optional[Sequence[Issue]]
-    trimmed_issues: Optional[Sequence[Issue]] = Field(alias="trimmedIssues")
+    id: Optional[str] = None
+    direction: Optional[Literal["OUTWARD", "INWARD", "BOTH"]] = None
+    link_type: Optional[IssueLinkType] = Field(alias="linkType", default=None)
+    issues: Optional[Sequence[Issue]] = None
+    trimmed_issues: Optional[Sequence[Issue]] = Field(alias="trimmedIssues", default=None)
 
 
 class AgileRef(BaseModel):
     type: Literal["Agile"] = Field(alias="$type", default="Agile")
-    id: Optional[str]
-    name: Optional[str]
+    id: Optional[str] = None
+    name: Optional[str] = None
 
 
 class SprintRef(BaseModel):
     type: Literal["Sprint"] = Field(alias="$type", default="Sprint")
-    id: Optional[str]
-    name: Optional[str]
+    id: Optional[str] = None
+    name: Optional[str] = None
 
 
 class Agile(AgileRef):
-    owner: Optional[User]
-    visible_for: Optional[UserGroup] = Field(alias="visibleFor")
-    projects: Optional[Sequence[Project]]
-    sprints: Optional[Sequence[SprintRef]]
-    current_sprint: Optional[SprintRef] = Field(alias="currentSprint")
+    owner: Optional[User] = None
+    visible_for: Optional[UserGroup] = Field(alias="visibleFor", default=None)
+    projects: Optional[Sequence[Project]] = None
+    sprints: Optional[Sequence[SprintRef]] = None
+    current_sprint: Optional[SprintRef] = Field(alias="currentSprint", default=None)
 
 
 class Sprint(SprintRef):
-    agile: Optional[AgileRef]
-    goal: Optional[str]
-    start: Optional[datetime]
-    finish: Optional[datetime]
-    archived: Optional[bool]
-    is_default: Optional[bool] = Field(alias="isDefault")
-    issues: Optional[Sequence[Issue]]
-    unresolved_issues_count: Optional[int] = Field(alias="unresolvedIssuesCount")
-    previous_sprint: Optional[SprintRef] = Field(alias="previousSprint")
+    agile: Optional[AgileRef] = None
+    goal: Optional[str] = None
+    start: Optional[AwareDatetime] = None
+    finish: Optional[AwareDatetime] = None
+    archived: Optional[bool] = None
+    is_default: Optional[bool] = Field(alias="isDefault", default=None)
+    issues: Optional[Sequence[Issue]] = None
+    unresolved_issues_count: Optional[int] = Field(alias="unresolvedIssuesCount", default=None)
+    previous_sprint: Optional[SprintRef] = Field(alias="previousSprint", default=None)

--- a/youtrack_sdk/exceptions.py
+++ b/youtrack_sdk/exceptions.py
@@ -1,6 +1,3 @@
-from pydantic.v1.errors import PydanticValueError
-
-
 class YouTrackException(Exception):
     pass
 
@@ -11,11 +8,3 @@ class YouTrackNotFound(YouTrackException):
 
 class YouTrackUnauthorized(YouTrackException):
     pass
-
-
-class StrictIntError(PydanticValueError):
-    msg_template = "value is not a valid integer"
-
-
-class IncompatibleFieldTypeError(PydanticValueError):
-    msg_template = "incompatible field type"

--- a/youtrack_sdk/helpers.py
+++ b/youtrack_sdk/helpers.py
@@ -4,7 +4,7 @@ from datetime import UTC, date, datetime, time
 from itertools import starmap
 from typing import Any, Optional, Type, Union, get_args
 
-from pydantic.v1 import BaseModel
+from pydantic import BaseModel
 
 
 def deep_update(dest: dict, *mappings: dict) -> dict:
@@ -47,8 +47,8 @@ def model_to_field_names(model: Type[BaseModel] | Union[Type[BaseModel]]) -> Opt
     """
 
     def model_to_fields(m: Type[BaseModel]) -> dict:
-        model_schema = m.schema(ref_template="{model}")
-        definitions = model_schema.get("definitions", {})
+        model_schema = m.model_json_schema(ref_template="{model}")
+        definitions = model_schema.get("$defs", {})
 
         def schema_to_fields(schema: dict) -> dict:
             def type_to_fields(field_type: dict) -> dict:
@@ -89,8 +89,8 @@ def obj_to_dict(obj: Optional[BaseModel]) -> Optional[dict]:
     # `exclude_unset=True` on its own is not sufficient, because the default value
     # for $type fields should be used to simplify the creation of request objects.
     return obj and deep_update(
-        obj.dict(by_alias=True, exclude_unset=True),
-        obj.dict(by_alias=True, exclude_none=True),
+        obj.model_dump(by_alias=True, exclude_unset=True),
+        obj.model_dump(by_alias=True, exclude_none=True),
     )
 
 


### PR DESCRIPTION
## V2 Notes

1. datetime validation now does not include timezone by default
   Custom datatype introduced to for this `TimeZoneDateTime`.
    ```python
   from datetime import datetime
   from pydantic import BaseModel

   class Foo(BaseModel):
       bar: datetime

   print(Foo(bar="1664200289671"))
   #v1: bar=datetime.datetime(2022, 9, 26, 13, 51, 29, 671000, tzinfo=datetime.timezone.utc)
   #v2: bar=datetime.datetime(2022, 9, 26, 13, 51, 29, 671000)
   ```
**A Fix was made by Pydantic, so datetime now includes timezone info by default.**
   
2. date validation: the input value 
provided for a date field must have a nonzero time component. For a 
timestamp to parse into a field of type date, the time components must all be zero. Else `date_from_datetime_inexact`
error is raised
   - Implication for `youtrack_sdk` is that some `date` type have to convert to custom date data type `UnixMidDayDate`
   e.g `DateIssueCustomField`

3. `parse_obj` renamed to model_validate
4. `parse_obj_as` replaced with `TypeAdapter`
5. `BaseModel` config now uses `ConfigDict`
6. Need to provide `None` default value for optional fields
7. ~~`PydanticValueError` replaced with `PydanticUserError`~~
8. `BaseModel.schema` replaced `BaseModel.model_json_schema`
9. `BaseModel.dict` replaced `BaseModel.model_dump`
10. `BaseModel.construct` replaced `BaseModel.model_construct`
11. ~~`from_unix_seconds` was removed in pydantic v2, so the implementation is now 
copied to `.helpers`~~