### PR TITLE
Feature/md 7041 publish python package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: moneymeets/action-setup-python-poetry@master
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish-package:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: moneymeets/action-setup-python-poetry@master
+
+      - name: Publish package
+        run: |
+          sed -i -e "s/1+SNAPSHOT/0.$(date +"%Y%m%d%H%M")+$(git rev-parse --verify --short=7 HEAD)/" pyproject.toml
+          poetry publish --build
+        env:
+          POETRY_HTTP_BASIC_PYPI_USERNAME: ${{ secrets.POETRY_HTTP_BASIC_PYPI_USERNAME }}
+          POETRY_HTTP_BASIC_PYPI_PASSWORD: ${{ secrets.POETRY_HTTP_BASIC_PYPI_PASSWORD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,23 @@
 [tool.poetry]
 name = "youtrack-sdk"
-version = "0.1.0"
-description = ""
-authors = []
+version = "1.1+SNAPSHOT"
+description = "YouTrack SDK"
+authors = ["moneymeets <service@moneymeets.com>"]
+readme = "README.md"
+repository = "https://github.com/moneymeets/youtrack-sdk"
+packages = [
+    { include = "youtrack_sdk" },
+]
+keywords = ["youtrack", "sdk"]
+license = "MIT"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "License :: OSI Approved :: MIT License",
+]
 
 [tool.poetry.dependencies]
 python = "~3.12"


### PR DESCRIPTION
Added possibility to publish Python package to PyPI, see https://github.com/moneymeets/youtrack-sdk/issues/32.

There is another PR to add the credentials: https://github.com/moneymeets/moneymeets-pulumi/pull/483, which I already applied.

We agreed on the following versioning schema:
locally: `1.1+SNAPSHOT`
published: `1.0.202310461046+gabcde`

The workflow can be tested by updating the branch from `master` to `feature/MD-7041-publish-python-package` in `publish.yml`.
Furthermore, there is a to-do item in `pyproject.toml`. @catcombo Please clarify and update this.
