### PR TITLE
Feature/add helpers

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,6 +71,9 @@ class TestClient(TestCase):
             timeout=123,
         )
 
+    def test_get_absolute_url(self):
+        self.assertEqual(self.client.get_absolute_url(path="/issue/1"), "https://server/issue/1")
+
     @mock_response(url="https://server/api/issues/1", response_name="issue")
     def test_get_issue(self):
         self.assertEqual(

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -41,6 +41,27 @@ class CustomIssue(BaseModel):
     custom_fields: Optional[Sequence[IssueCustomFieldType]] = Field(alias="customFields", default=None)
 
 
+TEST_STATE_CUSTOM_FIELD = StateIssueCustomField.model_construct(
+    id="110-50",
+    name="State",
+    type="StateIssueCustomField",
+    value=StateBundleElement.model_construct(
+        id="98-37",
+        name="In Progress",
+        type="StateBundleElement",
+    ),
+    project_custom_field=StateProjectCustomField.model_construct(
+        field=CustomField.model_construct(
+            type="CustomField",
+            field_type=FieldType.model_construct(
+                type="FieldType",
+                id="state[1]",
+            ),
+        ),
+        type="StateProjectCustomField",
+    ),
+)
+
 TEST_ISSUE = Issue.model_construct(
     type="Issue",
     id="1-937",
@@ -74,26 +95,7 @@ TEST_ISSUE = Issue.model_construct(
     comments_count=7,
     tags=[Tag.model_construct(type="Tag", id="5-7", name="Review")],
     custom_fields=[
-        StateIssueCustomField.model_construct(
-            id="110-50",
-            name="State",
-            type="StateIssueCustomField",
-            value=StateBundleElement.model_construct(
-                id="98-37",
-                name="In Progress",
-                type="StateBundleElement",
-            ),
-            project_custom_field=StateProjectCustomField.model_construct(
-                field=CustomField.model_construct(
-                    type="CustomField",
-                    field_type=FieldType.model_construct(
-                        type="FieldType",
-                        id="state[1]",
-                    ),
-                ),
-                type="StateProjectCustomField",
-            ),
-        ),
+        TEST_STATE_CUSTOM_FIELD,
         SingleUserIssueCustomField.model_construct(
             id="111-8",
             name="Assignee",

--- a/youtrack_sdk/client.py
+++ b/youtrack_sdk/client.py
@@ -133,6 +133,9 @@ class Client:
     def _delete(self, *, url: str) -> Optional[dict]:
         return self._send_request(method=HTTPMethod.DELETE, url=url)
 
+    def get_absolute_url(self, *, path: str) -> str:
+        return f"{self._base_url}{path}"
+
     def get_issue(self, *, issue_id: str) -> Issue:
         """Read an issue with specific ID.
 

--- a/youtrack_sdk/entities.py
+++ b/youtrack_sdk/entities.py
@@ -283,6 +283,10 @@ class Issue(BaseModel):
     tags: Optional[Sequence[Tag]] = None
     custom_fields: Optional[Sequence[IssueCustomFieldType]] = Field(alias="customFields", default=None)
 
+    @property
+    def url(self) -> str:
+        return f"/issue/{self.issue_id}"
+
 
 class IssueAttachment(BaseModel):
     type: Literal["IssueAttachment"] = Field(alias="$type", default="IssueAttachment")


### PR DESCRIPTION
This PR adds some useful methods and properties:
1. `url` property for the `Issue` model. It returns a relative URL that can be passed to the new `client.get_absolute_url()` method to construct a full URL.
2. `client.issue_exists()` method is a shortcut to check if issue exists.
3. `client.get_issue_custom_field()` helps with finding a specific custom field by name.